### PR TITLE
Firmament full loop

### DIFF
--- a/TheCollector/AutomationHandler.cs
+++ b/TheCollector/AutomationHandler.cs
@@ -39,6 +39,7 @@ public class AutomationHandler : IDisposable
 
     public int SessionCollectablesTurnedIn { get; private set; }
     public int SessionItemsPurchased { get; private set; }
+    public int SessionFullLoops { get; private set; }
     public Dictionary<uint, int> SessionScripsSpent { get; } = new();
     public Dictionary<uint, int> SessionScripsEarned { get; } = new();
     public DateTime? SessionStarted { get; private set; }
@@ -73,13 +74,18 @@ public class AutomationHandler : IDisposable
 
     public void Init()
     {
-        foreach (var system in _selector.All)
+        // Distinct() because systems can share pipeline instances (Inspection reuses the
+        // Firmament shop buy) — subscribing per-system would double-fire those events.
+        foreach (var turnIn in _selector.All.Select(s => s.TurnIn).Distinct())
         {
-            system.TurnIn.OnError += OnError;
-            system.TurnIn.OnFinished += OnFinishedCollecting;
-            system.TurnIn.OnScripsEarned += OnScripsEarned;
-            system.Buy.OnError += OnError;
-            system.Buy.OnFinishedTrading += OnFinishedTrading;
+            turnIn.OnError += OnError;
+            turnIn.OnFinished += OnFinishedCollecting;
+            turnIn.OnScripsEarned += OnScripsEarned;
+        }
+        foreach (var buy in _selector.All.Select(s => s.Buy).Distinct())
+        {
+            buy.OnError += OnError;
+            buy.OnFinishedTrading += OnFinishedTrading;
         }
         _gatherbuddyReborn_IPCSubscriber.OnAutoGatherStatusChanged += OnAutoGatherStatusChanged;
         _artisanWatcher.OnCraftingFinished += OnFinishedWatching;
@@ -91,11 +97,27 @@ public class AutomationHandler : IDisposable
         _deliverooManager.OnError += OnError;
     }
 
+    // Set when an autogather-triggered resource inspection should be followed by an Artisan
+    // list (gather -> inspect -> craft). Consumed once at the inspection run's terminal so the
+    // later post-craft turn-in doesn't restart crafting.
+    private bool _pendingCraftAfterInspection;
+
+    // When set, the loop drives this turn-in instead of the active system's. ActiveSystem stays
+    // Firmament (so the buy, goal, and post-craft/inventory-full/`collect` turn-ins use the
+    // appraiser); the Resource Inspection runs transiently — only after gathering or via
+    // /collector inspect — through this override. Cleared whenever Invoke()/ForceStop runs the
+    // active turn-in, so inspection never hijacks the other commands.
+    private ITurnInPipeline? _turnInOverride;
+    private ITurnInPipeline CurrentTurnIn => _turnInOverride ?? _selector.Active.TurnIn;
+
     private void OnAutoGatherStatusChanged(bool enabled)
     {
         if (enabled) return;
-        if (_config.ShouldCraftOnAutogatherChanged)
-            _craftingHandler.ShouldStartCrafting();
+        if (_config.RunInspectionOnAutogatherFinish)
+        {
+            _pendingCraftAfterInspection = _config.CraftOnInspectionFinish;
+            if (!InvokeInspection()) _pendingCraftAfterInspection = false;
+        }
         else if (_config.CollectOnAutogatherFinish)
             Invoke();
     }
@@ -142,7 +164,53 @@ public class AutomationHandler : IDisposable
         }
         SessionStarted ??= DateTime.UtcNow;
         _consecutiveEmptyBuyCycles = 0;
+        // A plain Invoke always runs the active system's turn-in (collect / post-craft /
+        // inventory-full), so drop any lingering inspection override.
+        _turnInOverride = null;
         _selector.Active.TurnIn.Start();
+        return true;
+    }
+
+    // Runs the Resource Inspection as a transient turn-in. ActiveSystem is kept on Firmament so
+    // the scrip cap -> buy uses the Firmament shop and every other turn-in (post-craft,
+    // inventory-full, /collector collect) still goes to the appraiser.
+    public bool InvokeInspection()
+    {
+        if (IsRunning)
+        {
+            _log.Debug("Automation is already running; ignoring inspection request.");
+            return false;
+        }
+        if (_config.HardFailReason != null)
+        {
+            _chatGui.PrintError($"Automation halted: {_config.HardFailReason}. Acknowledge it in the main window before retrying.", "TheCollector");
+            return false;
+        }
+        if (!_firmamentCatalog.IsReady)
+        {
+            _chatGui.PrintError("Still scanning Firmament data — try again in a few seconds.", "TheCollector");
+            return false;
+        }
+        if (Svc.Condition[ConditionFlag.InCombat])
+        {
+            _chatGui.PrintError("Cannot start automation while in combat.", "TheCollector");
+            return false;
+        }
+        if (PlayerEx.IsInDuty && Svc.ClientState.TerritoryType != _firmamentCatalog.TerritoryId)
+        {
+            _chatGui.PrintError("Cannot start automation while in a duty.", "TheCollector");
+            return false;
+        }
+        // Inspection is Firmament content; align the persistent system so the buy/goal/appraiser flow matches.
+        if (_config.ActiveSystem != ScripSystemId.Firmament)
+        {
+            _config.ActiveSystem = ScripSystemId.Firmament;
+            _config.Save();
+        }
+        SessionStarted ??= DateTime.UtcNow;
+        _consecutiveEmptyBuyCycles = 0;
+        _turnInOverride = _selector.Inspection.TurnIn;
+        _turnInOverride.Start();
         return true;
     }
 
@@ -163,7 +231,7 @@ public class AutomationHandler : IDisposable
             _chatGui.PrintError("Still scanning vendor data — try again in a few seconds.", "TheCollector");
             return false;
         }
-        if (_config.ActiveSystem == ScripSystemId.Firmament && !_firmamentCatalog.IsReady)
+        if (_config.ActiveSystem.IsFirmamentLike() && !_firmamentCatalog.IsReady)
         {
             _chatGui.PrintError("Still scanning Firmament data — try again in a few seconds.", "TheCollector");
             return false;
@@ -220,7 +288,7 @@ public class AutomationHandler : IDisposable
     }
 
 
-    private enum PostRunStage { ResumeArtisan, AutoRetainer, Deliveroo, Autogather }
+    private enum PostRunStage { ResumeArtisan, StartCraft, AutoRetainer, Deliveroo, Autogather }
 
     private bool TryStartStage(PostRunStage stage)
     {
@@ -230,6 +298,16 @@ public class AutomationHandler : IDisposable
                 if (!_artisanWatcher.IsPausedByUs) return false;
                 _artisanWatcher.ResumeAfterTurnIn();
                 _chatGui.Print("Turn-in done — resuming Artisan list.", "TheCollector");
+                return true;
+
+            case PostRunStage.StartCraft:
+                // After an autogather-triggered inspection, kick off the Artisan list once
+                // (gather -> inspect -> craft). ResumeArtisan above already handled the
+                // inventory-full-during-crafting case, so we only reach here for a fresh start.
+                if (!_pendingCraftAfterInspection) return false;
+                _pendingCraftAfterInspection = false;
+                _craftingHandler.ShouldStartCrafting();
+                _chatGui.Print("Resource inspection done — starting Artisan list.", "TheCollector");
                 return true;
 
             case PostRunStage.AutoRetainer:
@@ -247,6 +325,18 @@ public class AutomationHandler : IDisposable
 
             case PostRunStage.Autogather:
                 if (!_config.EnableAutogatherOnFinish) return false;
+                // Re-enabling autogather closes one full loop and starts the next. Count it, and
+                // honour the iteration cap by stopping here instead of re-gathering (the current
+                // cycle is already complete).
+                SessionFullLoops++;
+                var stop = _config.Stop;
+                if (stop.StopOnFullLoopsEnabled && stop.MaxFullLoops > 0 && SessionFullLoops >= stop.MaxFullLoops)
+                {
+                    var reason = $"Reached full-loop limit ({SessionFullLoops}/{stop.MaxFullLoops}).";
+                    _chatGui.Print($"Stop condition met: {reason}", "TheCollector");
+                    _discord.Notify(DiscordEvent.StopCondition, $"🛑 TheCollector stopped: {reason}");
+                    return true; // handled — stop without re-enabling autogather
+                }
                 _gatherbuddyReborn_IPCSubscriber.SetAutoGatherEnabled(true);
                 return true;
 
@@ -266,6 +356,8 @@ public class AutomationHandler : IDisposable
     public void OnDeliverooFinish() => RunPostRunCascade(PostRunStage.Autogather);
     public void ForceStop(string reason)
     {
+        _pendingCraftAfterInspection = false;
+        _turnInOverride = null;
         // If we're mid-turn-in on a self-pause, drop the bookkeeping (leaving Artisan
         // stopped, since everything is halting) so the watcher isn't permanently stuck.
         if (_artisanWatcher.IsPausedByUs)
@@ -319,7 +411,7 @@ public class AutomationHandler : IDisposable
         SessionCollectablesTurnedIn++;
         _balanceTracker.SampleNow();
 
-        if (_selector.Active.TurnIn.LastEarnedCurrency is { } earned)
+        if (CurrentTurnIn.LastEarnedCurrency is { } earned)
         {
             var source = CurrencyHelper.GetRunSource(earned);
             if (_config.ActiveRunSource != source)
@@ -331,13 +423,17 @@ public class AutomationHandler : IDisposable
 
         if (TryStopOnConditionMet()) return;
 
-        if (_selector.Active.TurnIn.CapReached || _config.BuyAfterEachCollect)
+        if (CurrentTurnIn.CapReached || _config.BuyAfterEachCollect)
         {
-            if (_selector.Active.TurnIn.CapReached)
+            if (CurrentTurnIn.CapReached)
                 _discord.Notify(DiscordEvent.ScripCap, "💰 TheCollector: scrip cap reached, moving to shop.");
+            // Keep the override across the buy so OnFinishedTrading resumes the same turn-in.
             _selector.Active.Buy.Start();
             return;
         }
+        // Turn-in fully done — drop any inspection override so the cascade and the next turn-in
+        // (post-craft / inventory-full / collect) use the active system's appraiser.
+        _turnInOverride = null;
         RunPostRunCascade(PostRunStage.ResumeArtisan);
     }
     private void OnFinishedTrading(Dictionary<uint, int> scripsSpent)
@@ -355,7 +451,7 @@ public class AutomationHandler : IDisposable
             totalSpent += amount;
         }
         _config.Save();
-        var activeIsFirmament = _selector.Active.Id == ScripSystemId.Firmament;
+        var activeIsFirmament = _selector.Active.Id.IsFirmamentLike();
         var activeGoal = activeIsFirmament ? _config.FirmamentGoal : _config.Goal;
 
         if (_config.ResetEachQuantityAfterCompletingList)
@@ -388,12 +484,13 @@ public class AutomationHandler : IDisposable
             // bookkeeping or the watcher stays blind forever (Artisan stays stopped on purpose).
             if (_artisanWatcher.IsPausedByUs)
                 _artisanWatcher.AbandonPause();
+            _turnInOverride = null;
             return;
         }
 
         if (TryStopOnConditionMet()) return;
 
-        if (_selector.Active.TurnIn.HasCollectible)
+        if (CurrentTurnIn.HasCollectible)
         {
             if (totalSpent == 0)
             {
@@ -409,10 +506,11 @@ public class AutomationHandler : IDisposable
                 _consecutiveEmptyBuyCycles = 0;
             }
 
-            _selector.Active.TurnIn.Start();
+            CurrentTurnIn.Start();
             return;
         }
         _consecutiveEmptyBuyCycles = 0;
+        _turnInOverride = null;
         RunPostRunCascade(PostRunStage.ResumeArtisan);
     }
 
@@ -442,13 +540,16 @@ public class AutomationHandler : IDisposable
 
     public void Dispose()
     {
-        foreach (var system in _selector.All)
+        foreach (var turnIn in _selector.All.Select(s => s.TurnIn).Distinct())
         {
-            system.TurnIn.OnError -= OnError;
-            system.TurnIn.OnFinished -= OnFinishedCollecting;
-            system.TurnIn.OnScripsEarned -= OnScripsEarned;
-            system.Buy.OnError -= OnError;
-            system.Buy.OnFinishedTrading -= OnFinishedTrading;
+            turnIn.OnError -= OnError;
+            turnIn.OnFinished -= OnFinishedCollecting;
+            turnIn.OnScripsEarned -= OnScripsEarned;
+        }
+        foreach (var buy in _selector.All.Select(s => s.Buy).Distinct())
+        {
+            buy.OnError -= OnError;
+            buy.OnFinishedTrading -= OnFinishedTrading;
         }
         _gatherbuddyReborn_IPCSubscriber.OnAutoGatherStatusChanged -= OnAutoGatherStatusChanged;
         _artisanWatcher.OnCraftingFinished -= OnFinishedWatching;

--- a/TheCollector/AutomationHandler.cs
+++ b/TheCollector/AutomationHandler.cs
@@ -7,6 +7,7 @@ using ECommons.DalamudServices;
 using ECommons.GameHelpers;
 using TheCollector.CollectableManager;
 using TheCollector.Data;
+using TheCollector.FirmamentManager;
 using TheCollector.Data.Models;
 using TheCollector.Data.ScripSystem;
 using TheCollector.Ipc;
@@ -35,6 +36,8 @@ public class AutomationHandler : IDisposable
     private readonly DiscordWebhookService _discord;
     private readonly CharacterBalanceTracker _balanceTracker;
     private readonly VendorCatalog _vendorCatalog;
+    private readonly KupoOfFortuneHandler _kupo;
+    private readonly FirmamentTurnInWindowHandler _firmamentTurnInWindow;
     public bool IsRunning => _pipelineRegistry.All.Any(p => p.IsRunning);
 
     public int SessionCollectablesTurnedIn { get; private set; }
@@ -48,8 +51,12 @@ public class AutomationHandler : IDisposable
     private int _consecutiveEmptyBuyCycles;
     private const int HardFailThreshold = 2;
 
+    // True while a Kupo of Fortune run was started manually (debug/test button) rather than
+    // by the turn-in loop, so its completion does not spill into the post-turn-in cascade.
+    private bool _kupoStartedManually;
+
     public AutomationHandler(
-        PlogonLog log, ScripSystemSelector selector, Configuration config, FirmamentCatalog firmamentCatalog, IChatGui chatGui, GatherbuddyReborn_IPCSubscriber gatherbuddyReborn_IPCSubscriber, ArtisanWatcher artisanWatcher, IFramework framework, FishingWatcher fishingWatcher, CraftingHandler craftingHandler, PipelineRegistry registry, AutoRetainerManager retainer, DeliverooManager deliveroo, ScripPlannerService plannerService, FirmamentPlannerService firmamentPlannerService, DiscordWebhookService discord, CharacterBalanceTracker balanceTracker, VendorCatalog vendorCatalog)
+        PlogonLog log, ScripSystemSelector selector, Configuration config, FirmamentCatalog firmamentCatalog, IChatGui chatGui, GatherbuddyReborn_IPCSubscriber gatherbuddyReborn_IPCSubscriber, ArtisanWatcher artisanWatcher, IFramework framework, FishingWatcher fishingWatcher, CraftingHandler craftingHandler, PipelineRegistry registry, AutoRetainerManager retainer, DeliverooManager deliveroo, ScripPlannerService plannerService, FirmamentPlannerService firmamentPlannerService, DiscordWebhookService discord, CharacterBalanceTracker balanceTracker, VendorCatalog vendorCatalog, KupoOfFortuneHandler kupo, FirmamentTurnInWindowHandler firmamentTurnInWindow)
     {
         _log = log;
         _gatherbuddyReborn_IPCSubscriber = gatherbuddyReborn_IPCSubscriber;
@@ -69,6 +76,8 @@ public class AutomationHandler : IDisposable
         _discord = discord;
         _balanceTracker = balanceTracker;
         _vendorCatalog = vendorCatalog;
+        _kupo = kupo;
+        _firmamentTurnInWindow = firmamentTurnInWindow;
     }
 
     public void Init()
@@ -89,6 +98,8 @@ public class AutomationHandler : IDisposable
         _autoretainerManager.OnError += OnError;
         _deliverooManager.OnDeliverooFinish += OnDeliverooFinish;
         _deliverooManager.OnError += OnError;
+        _kupo.OnFinishedPlaying += OnKupoFinished;
+        _kupo.OnError += OnKupoError;
     }
 
     private void OnAutoGatherStatusChanged(bool enabled)
@@ -170,6 +181,25 @@ public class AutomationHandler : IDisposable
         }
         SessionStarted ??= DateTime.UtcNow;
         _selector.Active.Buy.Start();
+        return true;
+    }
+
+    // Standalone Kupo of Fortune run for testing — plays the minigame at Lizbeth without
+    // running (or continuing into) the rest of the automation loop.
+    public bool InvokeKupo()
+    {
+        if (IsRunning)
+        {
+            _chatGui.PrintError("Automation is already running.", "TheCollector");
+            return false;
+        }
+        if (!_firmamentCatalog.IsReady)
+        {
+            _chatGui.PrintError("Still scanning Firmament data — try again in a few seconds.", "TheCollector");
+            return false;
+        }
+        _kupoStartedManually = true;
+        _kupo.Start();
         return true;
     }
 
@@ -331,6 +361,53 @@ public class AutomationHandler : IDisposable
 
         if (TryStopOnConditionMet()) return;
 
+        // Drain Kupo of Fortune cards (Firmament-only) before the buy/cascade flow; it
+        // resumes via ContinueAfterCollect on finish, or OnKupoError on failure.
+        if (ShouldPlayKupo())
+        {
+            _kupoStartedManually = false;
+            _kupo.Start();
+            return;
+        }
+
+        ContinueAfterCollect();
+    }
+
+    private void OnKupoFinished()
+    {
+        // A manual test run ends here without spilling into the buy/cascade flow.
+        if (_kupoStartedManually) { _kupoStartedManually = false; return; }
+
+        // The turn-in pauses when vouchers hit the threshold; having drained them, resume
+        // turning in if collectables remain (and we're not at the scrip cap). This interleaves
+        // turn-in and Kupo so vouchers never pile up past the cap.
+        if (!_selector.Active.TurnIn.CapReached && _selector.Active.TurnIn.HasCollectible)
+        {
+            _selector.Active.TurnIn.Start();
+            return;
+        }
+        ContinueAfterCollect();
+    }
+
+    private bool ShouldPlayKupo()
+    {
+        // Firmament-only, gated on the voucher count sampled from the turn-in window so we
+        // only detour to Lizbeth once the held vouchers reach the threshold (default = cap).
+        return _config.KupoOfFortuneEnabled &&
+               _selector.Active.Id == ScripSystemId.Firmament &&
+               _firmamentTurnInWindow.LastVoucherCount >= _config.KupoOfFortuneThreshold;
+    }
+
+    private void OnKupoError(Exception ex)
+    {
+        // A failed minigame must not hard-fail the whole run — just log and carry on.
+        _log.Error(ex, "Kupo of Fortune play failed; continuing with the post-turn-in flow.");
+        if (_kupoStartedManually) { _kupoStartedManually = false; return; }
+        ContinueAfterCollect();
+    }
+
+    private void ContinueAfterCollect()
+    {
         if (_selector.Active.TurnIn.CapReached || _config.BuyAfterEachCollect)
         {
             if (_selector.Active.TurnIn.CapReached)

--- a/TheCollector/Configuration.cs
+++ b/TheCollector/Configuration.cs
@@ -22,8 +22,11 @@ public class Configuration : IPluginConfiguration
     public List<ItemToPurchase> ItemsToPurchase { get; set; } = new List<ItemToPurchase>();
     public bool EnableAutogatherOnFinish { get; set; } = false;
     public bool CollectOnFinishCraftingList { get; set; } = false;
-    public bool ShouldCraftOnAutogatherChanged { get; set; } = false;
+    // Start the Artisan list once a resource-inspection run completes (gather -> inspect -> craft).
+    public bool CraftOnInspectionFinish { get; set; } = false;
     public bool CollectOnAutogatherFinish { get; set; } = false;
+    // Run the Skybuilders' resource inspection when GatherBuddyReborn autogather finishes.
+    public bool RunInspectionOnAutogatherFinish { get; set; } = false;
     public bool BuyAfterEachCollect { get; set; } = false;
     public bool ResetEachQuantityAfterCompletingList { get; set; } = false;
     public bool CollectOnFinishedFishing { get; set; } = false;

--- a/TheCollector/Configuration.cs
+++ b/TheCollector/Configuration.cs
@@ -68,6 +68,10 @@ public class Configuration : IPluginConfiguration
     public bool KupoOfFortuneEnabled { get; set; } = false;
     public int KupoOfFortuneThreshold { get; set; } = 10;
 
+    // Which chest to scratch on each Kupo of Fortune card. Left only wins 2nd-4th prize;
+    // the three right chests can win any of the 5 (incl. the jackpot and the consolation).
+    public KupoChestPick KupoChestPick { get; set; } = KupoChestPick.Left;
+
     public void Save()
     {
         Svc.PluginInterface.SavePluginConfig(this);

--- a/TheCollector/Configuration.cs
+++ b/TheCollector/Configuration.cs
@@ -61,6 +61,13 @@ public class Configuration : IPluginConfiguration
 
     public ScripGoal FirmamentGoal { get; set; } = new();
 
+    // When enabled, after a Firmament turn-in run the plugin will walk to Lizbeth and
+    // play the Kupo of Fortune minigame to drain held cards (which otherwise cap at 10,
+    // wasting any further vouchers earned). Only triggers when the held-card count is at
+    // or above KupoOfFortuneThreshold. Firmament-only; off by default.
+    public bool KupoOfFortuneEnabled { get; set; } = false;
+    public int KupoOfFortuneThreshold { get; set; } = 10;
+
     public void Save()
     {
         Svc.PluginInterface.SavePluginConfig(this);

--- a/TheCollector/Data/Firmament/FirmamentAnchors.cs
+++ b/TheCollector/Data/Firmament/FirmamentAnchors.cs
@@ -1,3 +1,5 @@
+using System.Numerics;
+
 namespace TheCollector.Data.Firmament;
 
 public static class FirmamentAnchors
@@ -7,4 +9,16 @@ public static class FirmamentAnchors
     public const uint ExchangeTalkId = 721546;
 
     public const uint ScripItemId = 28063;
+
+    // Lizbeth runs the Kupo of Fortune lottery in The Firmament. Several ENpcResident rows
+    // share the name "Lizbeth"; the catalog keeps only the placement that resolves to the
+    // Firmament territory, so listing every candidate here stays language-independent.
+    public static readonly uint[] LizbethNpcIds = { 1031679, 1031692, 1035535 };
+
+    // The confirmed Firmament Lizbeth (verified in-game via /xldev: targeting her reports
+    // base id 1031692 at this world position). Pinned as a guaranteed anchor so the catalog
+    // always has a working id + spot even if the Level-sheet scan or live object lookup
+    // comes up empty.
+    public const uint LizbethNpcId = 1031692;
+    public static readonly Vector3 LizbethPosition = new(52.780884f, -16.000002f, 170.61108f);
 }

--- a/TheCollector/Data/KupoChestPick.cs
+++ b/TheCollector/Data/KupoChestPick.cs
@@ -1,0 +1,11 @@
+namespace TheCollector.Data;
+
+// Which chest to scratch on a Kupo of Fortune card.
+public enum KupoChestPick
+{
+    // The lone left hexagon — can only win 2nd through 4th prize.
+    Left,
+
+    // A random one of the three right hexagons — can win any of the 5 prizes.
+    RandomRight,
+}

--- a/TheCollector/Data/Models/StopConditions.cs
+++ b/TheCollector/Data/Models/StopConditions.cs
@@ -10,4 +10,9 @@ public class StopConditions
 
     public bool StopOnSessionTimeEnabled { get; set; } = false;
     public int MaxSessionMinutes { get; set; } = 120;
+
+    // One full loop = a complete gather -> inspect -> craft -> ... cycle, counted each time
+    // autogather is re-enabled to start the next one. Stops after finishing the current cycle.
+    public bool StopOnFullLoopsEnabled { get; set; } = false;
+    public int MaxFullLoops { get; set; } = 5;
 }

--- a/TheCollector/Data/PluginState.cs
+++ b/TheCollector/Data/PluginState.cs
@@ -15,6 +15,7 @@ public enum PluginState
     [Description("Idle")]                 Idle,
     [Description("AutoRetainer running")] AutoRetainer,
     [Description("Deliveroo running")]    Deliveroo,
+    [Description("Crafting Artisan list")] ProcessingArtisanList,
 }
 
 public static class PluginStateExtensions

--- a/TheCollector/Data/ScripSystem/ResourceInspectionScripSystem.cs
+++ b/TheCollector/Data/ScripSystem/ResourceInspectionScripSystem.cs
@@ -1,0 +1,21 @@
+using TheCollector.FirmamentManager;
+using TheCollector.ResourceInspectionManager;
+
+namespace TheCollector.Data.ScripSystem;
+
+// Pairs the Resource Inspection turn-in (Flotpassant) with the existing Firmament shop buy.
+// Both earn/spend Skybuilders' Scrip at the same 10,000 cap, so reusing FirmamentShopHandler
+// lets AutomationHandler's turn-in -> (cap) -> buy -> turn-in loop drive cap handling for free.
+public sealed class ResourceInspectionScripSystem : IScripSystem
+{
+    public ScripSystemId Id => ScripSystemId.Inspection;
+    public string DisplayName => "Resource Inspection";
+    public ITurnInPipeline TurnIn { get; }
+    public IBuyPipeline Buy { get; }
+
+    public ResourceInspectionScripSystem(ResourceInspectionHandler turnIn, FirmamentShopHandler buy)
+    {
+        TurnIn = turnIn;
+        Buy = buy;
+    }
+}

--- a/TheCollector/Data/ScripSystem/ScripSystemId.cs
+++ b/TheCollector/Data/ScripSystem/ScripSystemId.cs
@@ -4,4 +4,15 @@ public enum ScripSystemId
 {
     Normal,
     Firmament,
+    // Skybuilders' Resource Inspection (Flotpassant). Shares the Firmament currency, cap,
+    // purchase list, planner and shop — only the turn-in step differs.
+    Inspection,
+}
+
+public static class ScripSystemIds
+{
+    // Inspection rides on the Firmament economy (same Skybuilders' Scrip, goal, planner, shop),
+    // so every Firmament-goal/UI branch must treat it the same.
+    public static bool IsFirmamentLike(this ScripSystemId id) =>
+        id is ScripSystemId.Firmament or ScripSystemId.Inspection;
 }

--- a/TheCollector/Data/ScripSystem/ScripSystemSelector.cs
+++ b/TheCollector/Data/ScripSystem/ScripSystemSelector.cs
@@ -7,16 +7,22 @@ public sealed class ScripSystemSelector
     private readonly Configuration _config;
     public IScripSystem Normal { get; }
     public IScripSystem Firmament { get; }
+    public IScripSystem Inspection { get; }
 
-    public ScripSystemSelector(Configuration config, NormalScripSystem normal, FirmamentScripSystem firmament)
+    public ScripSystemSelector(Configuration config, NormalScripSystem normal, FirmamentScripSystem firmament, ResourceInspectionScripSystem inspection)
     {
         _config = config;
         Normal = normal;
         Firmament = firmament;
+        Inspection = inspection;
     }
 
-    public IScripSystem Active =>
-        _config.ActiveSystem == ScripSystemId.Firmament ? Firmament : Normal;
+    public IScripSystem Active => _config.ActiveSystem switch
+    {
+        ScripSystemId.Firmament => Firmament,
+        ScripSystemId.Inspection => Inspection,
+        _ => Normal,
+    };
 
-    public IReadOnlyList<IScripSystem> All => new[] { Normal, Firmament };
+    public IReadOnlyList<IScripSystem> All => new[] { Normal, Firmament, Inspection };
 }

--- a/TheCollector/FirmamentManager/FirmamentTurnInHandler.Pipeline.cs
+++ b/TheCollector/FirmamentManager/FirmamentTurnInHandler.Pipeline.cs
@@ -83,7 +83,15 @@ public partial class FirmamentTurnInHandler
             TurnInDriver(),
             FrameRunner.Delay("PostTurnInBuffer", TimeSpan.FromSeconds(1)),
             new FrameRunner.Step("CloseAppraiser",
-                () => { _window.CloseWindow(); _targetManager.Target = null; return StepResult.Success(); },
+                () =>
+                {
+                    // Sample the Kupo voucher count while the window is still open so the
+                    // post-turn-in flow can decide whether to play Kupo of Fortune.
+                    _window.TryGetVoucherCount(out _);
+                    _window.CloseWindow();
+                    _targetManager.Target = null;
+                    return StepResult.Success();
+                },
                 TimeSpan.FromSeconds(5)),
             FrameRunner.Delay("FinalDelay", TimeSpan.FromSeconds(1)),
         };
@@ -136,6 +144,17 @@ public partial class FirmamentTurnInHandler
             {
                 Log.Debug("Skybuilders' Scrip cap reached; stopping turn-in.");
                 CapReached = true;
+                return StepResult.Success();
+            }
+
+            // Pause the batch when held Kupo vouchers reach the threshold so the orchestrator
+            // can play them off (and we resume turning in afterwards) — otherwise vouchers
+            // earned past the cap of 10 are wasted before the run ends.
+            if (_configuration.KupoOfFortuneEnabled &&
+                _window.TryGetVoucherCount(out var vouchers) &&
+                vouchers >= _configuration.KupoOfFortuneThreshold)
+            {
+                Log.Debug($"Kupo voucher threshold reached ({vouchers}/{_configuration.KupoOfFortuneThreshold}); pausing turn-in to play.");
                 return StepResult.Success();
             }
 

--- a/TheCollector/FirmamentManager/FirmamentTurnInWindowHandler.cs
+++ b/TheCollector/FirmamentManager/FirmamentTurnInWindowHandler.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+using Dalamud.Memory;
 using ECommons;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -19,6 +21,34 @@ public unsafe class FirmamentTurnInWindowHandler
     public bool IsReady =>
         GenericHelpers.TryGetAddonByName<AtkUnitBase>(AddonName, out var addon) &&
         GenericHelpers.IsAddonReady(addon);
+
+    // Held Kupo of Fortune vouchers as last read from this window's "Kupo Vouchers N/10"
+    // counter, or -1 if not seen yet. Sampled during turn-in and used to gate the minigame.
+    public int LastVoucherCount { get; private set; } = -1;
+
+    // Reads the Kupo voucher count from the window's "N/10" counter. The Skybuilders' Scrip
+    // total ("6,120/10,000") is the only other "n/m" string and carries separators, so an
+    // unseparated "(digits)/(digits)" match uniquely identifies the voucher counter.
+    public bool TryGetVoucherCount(out int current)
+    {
+        current = -1;
+        if (!GenericHelpers.TryGetAddonByName<AtkUnitBase>(AddonName, out var addon) ||
+            !GenericHelpers.IsAddonReady(addon))
+            return false;
+
+        for (var i = 0; i < addon->AtkValuesCount; i++)
+        {
+            ref var v = ref addon->AtkValues[i];
+            if (v.Type != ValueType.String || v.String.Value == null) continue;
+            var text = MemoryHelper.ReadSeStringNullTerminated((nint)v.String.Value).TextValue;
+            var match = Regex.Match(text, @"^(\d+)/(\d+)$");
+            if (!match.Success) continue;
+            current = int.Parse(match.Groups[1].Value);
+            LastVoucherCount = current;
+            return true;
+        }
+        return false;
+    }
 
     public void SelectJob(int jobIndex)
     {

--- a/TheCollector/FirmamentManager/KupoOfFortuneHandler.Pipeline.cs
+++ b/TheCollector/FirmamentManager/KupoOfFortuneHandler.Pipeline.cs
@@ -1,0 +1,207 @@
+using System;
+using Dalamud.Game.ClientState.Conditions;
+using ECommons.DalamudServices;
+using ECommons.GameHelpers;
+using TheCollector.Data;
+using TheCollector.Ipc;
+using TheCollector.Utility;
+
+namespace TheCollector.FirmamentManager;
+
+public partial class KupoOfFortuneHandler
+{
+    // Cap on cards drained in one run: the game holds at most 10, plus a little slack so a
+    // miscount can never spin the loop forever.
+    private const int MaxCardsPerRun = 12;
+
+    private static readonly TimeSpan InteractInterval = TimeSpan.FromMilliseconds(700);
+    // Minimum dwell after scratching so the choice registers before we close the result.
+    private static readonly TimeSpan ScratchSettle = TimeSpan.FromMilliseconds(600);
+    // After interacting, how long to wait for a card to be offered before concluding there
+    // are no vouchers left. The timer is held off while any dialogue/event is in progress.
+    private static readonly TimeSpan OfferGrace = TimeSpan.FromSeconds(3);
+
+    // Each card is a self-contained NPC conversation: interact -> intro -> "play?" yes/no ->
+    // scratch card -> reward -> post-card lines -> conversation ends. We must re-interact for
+    // every card, so the drain runs as a small state machine over these phases.
+    private enum KupoPhase { Interact, AwaitOffer, Play, PostCard }
+
+    private int _cardsPlayed;
+
+    protected override FrameRunner.Step[] BuildSteps()
+    {
+        _cardsPlayed = 0;
+
+        if (_clientState.TerritoryType != _catalog.TerritoryId)
+        {
+            Log.Debug("Not in The Firmament; skipping Kupo of Fortune.");
+            return new[] { new FrameRunner.Step("SkipKupo", () => StepResult.Success(), TimeSpan.FromSeconds(1)) };
+        }
+
+        if (_catalog.LizbethDataIds.Length == 0)
+            Log.Information("Kupo of Fortune: Lizbeth placement not resolved; will move to the appraiser spot and attempt to interact.");
+
+        return new[]
+        {
+            new FrameRunner.Step("CanActCheck",
+                () => PlayerEx.CanAct ? StepResult.Success() : StepResult.Continue(),
+                TimeSpan.FromSeconds(30)),
+            new FrameRunner.Step("MoveToLizbeth",
+                MoveToLizbethTick,
+                TimeSpan.FromSeconds(60),
+                ResetMoveThrottle),
+            DrainCardsStep(),
+            FrameRunner.Delay("PostPlayBuffer", TimeSpan.FromSeconds(1)),
+            new FrameRunner.Step("ClearTarget",
+                () => { _targetManager.Target = null; return StepResult.Success(); },
+                TimeSpan.FromSeconds(5)),
+        };
+    }
+
+    protected override void OnFinished(bool ok)
+    {
+        base.OnFinished(ok);
+        if (ok) OnFinishedPlaying?.Invoke();
+    }
+
+    protected override void OnCanceledOrFailed(string? error)
+    {
+        base.OnCanceledOrFailed(error);
+        VNavmesh_IPCSubscriber.Path_Stop();
+    }
+
+    private StepResult MoveToLizbethTick()
+    {
+        Status.Set(PluginState.MovingToCollectableVendor, "to Lizbeth");
+        return MoveTowardsTick(FirmamentRouting.LivePosition(_catalog.LizbethDataIds, _catalog.LizbethPosition));
+    }
+
+    // Drains every held card as a state machine over one long-running step. Each card is its
+    // own conversation, so we re-interact per card; we stop when interacting no longer yields
+    // a "play?" prompt (no vouchers left) or the safety cap is hit.
+    private FrameRunner.Step DrainCardsStep()
+    {
+        var phase = KupoPhase.Interact;
+        var cardScratched = false;
+        var settleUntil = DateTime.MinValue;
+        var nextAction = DateTime.MinValue;
+        var nextClose = DateTime.MinValue;
+        var offerDeadline = DateTime.MinValue;
+        return new FrameRunner.Step("DrainKupoCards",
+            () =>
+            {
+                var now = DateTime.UtcNow;
+                Status.Set(PluginState.ExchangingItems, "Kupo of Fortune");
+
+                var lottery = _window.IsLotteryOpen;
+                var yesNo = _window.IsYesNoOpen;
+                var talk = _window.IsTalkOpen;
+                var occupied = Svc.Condition[ConditionFlag.OccupiedInQuestEvent] ||
+                               Svc.Condition[ConditionFlag.OccupiedInEvent];
+
+                // A lottery card open always means "go play it", regardless of phase.
+                if (lottery && phase != KupoPhase.Play)
+                    phase = KupoPhase.Play;
+
+                switch (phase)
+                {
+                    case KupoPhase.Interact:
+                        if (now >= nextAction)
+                        {
+                            VNavmesh_IPCSubscriber.Path_Stop();
+                            TryInteractWithLizbeth();
+                            nextAction = now + InteractInterval;
+                            offerDeadline = now + OfferGrace;
+                            phase = KupoPhase.AwaitOffer;
+                        }
+                        return StepResult.Continue();
+
+                    case KupoPhase.AwaitOffer:
+                        // Accept the "play?" prompt or advance the intro dialogue. While any
+                        // dialogue/event is up, hold off the no-offer deadline. The decision to
+                        // play at all was already made by the caller (loop threshold gate or the
+                        // manual test button), so here we always confirm.
+                        if (yesNo)
+                        {
+                            offerDeadline = now + OfferGrace;
+                            if (now >= nextAction)
+                            {
+                                _window.ConfirmYesNo();
+                                nextAction = now + InteractInterval;
+                            }
+                            return StepResult.Continue();
+                        }
+                        if (talk)
+                        {
+                            offerDeadline = now + OfferGrace;
+                            if (now >= nextAction)
+                            {
+                                _window.ProgressTalk();
+                                nextAction = now + InteractInterval;
+                            }
+                            return StepResult.Continue();
+                        }
+                        if (occupied) { offerDeadline = now + OfferGrace; return StepResult.Continue(); }
+                        if (now < offerDeadline) return StepResult.Continue();
+                        // Interacted but nothing was offered -> no vouchers left.
+                        Log.Debug($"Kupo of Fortune: no more vouchers; {_cardsPlayed} played, finishing.");
+                        return StepResult.Success();
+
+                    case KupoPhase.Play:
+                        if (lottery)
+                        {
+                            if (!cardScratched)
+                            {
+                                _window.Scratch();
+                                cardScratched = true;
+                                settleUntil = now + ScratchSettle;
+                                return StepResult.Continue();
+                            }
+                            if (now < settleUntil) return StepResult.Continue();
+                            if (!_window.IsRevealComplete) return StepResult.Continue();
+                            if (now >= nextClose)
+                            {
+                                _window.CloseLottery();
+                                nextClose = now + InteractInterval;
+                            }
+                            return StepResult.Continue();
+                        }
+                        // Lottery closed -> the card is done.
+                        if (cardScratched)
+                        {
+                            _cardsPlayed++;
+                            Log.Debug($"Kupo of Fortune: played card #{_cardsPlayed}.");
+                            cardScratched = false;
+                        }
+                        if (_cardsPlayed >= MaxCardsPerRun)
+                        {
+                            Log.Debug($"Kupo of Fortune: hit the {MaxCardsPerRun}-card safety cap, finishing.");
+                            return StepResult.Success();
+                        }
+                        phase = KupoPhase.PostCard;
+                        return StepResult.Continue();
+
+                    case KupoPhase.PostCard:
+                        // Advance the post-card lines; once the conversation ends, re-interact
+                        // for the next card until vouchers run out.
+                        if (talk || yesNo)
+                        {
+                            if (now >= nextAction)
+                            {
+                                if (!_window.ProgressTalk()) _window.ConfirmYesNo();
+                                nextAction = now + InteractInterval;
+                            }
+                            return StepResult.Continue();
+                        }
+                        if (occupied) return StepResult.Continue();
+                        nextAction = DateTime.MinValue;
+                        phase = KupoPhase.Interact;
+                        return StepResult.Continue();
+
+                    default:
+                        return StepResult.Success();
+                }
+            },
+            TimeSpan.FromSeconds(300));
+    }
+}

--- a/TheCollector/FirmamentManager/KupoOfFortuneHandler.Pipeline.cs
+++ b/TheCollector/FirmamentManager/KupoOfFortuneHandler.Pipeline.cs
@@ -21,6 +21,14 @@ public partial class KupoOfFortuneHandler
     private TimeSpan UiInteractDelay => TimeSpan.FromMilliseconds(_configuration.UiDelayMs);
     // Dwell after scratching so the choice registers before we close the result.
     private TimeSpan ScratchSettle => UiInteractDelay;
+    // A freshly opened Talk/SelectYesno/lottery addon reports "ready" (visible) a frame or two
+    // before its backing event Lua coroutine is actually live. Firing the advance/confirm/scratch
+    // callback inside that open-transition window resumes a null coroutine and crashes the game
+    // natively (Common::Lua::LuaThread.Resume access violation). Require any addon to be
+    // continuously ready for this long before we touch it — this is what actually prevents the
+    // crash where we clicked the post-card Talk on its first ready frame after the lottery closed.
+    // Independent of UiDelayMs so lowering the UI Delay can't shrink the guard below the safe window.
+    private static readonly TimeSpan DialogueSettle = TimeSpan.FromMilliseconds(300);
     // After interacting, how long to wait for a card to be offered before concluding there
     // are no vouchers left. The timer is held off while any dialogue/event is in progress.
     private static readonly TimeSpan OfferGrace = TimeSpan.FromSeconds(3);
@@ -91,6 +99,11 @@ public partial class KupoOfFortuneHandler
         var nextAction = DateTime.MinValue;
         var nextClose = DateTime.MinValue;
         var offerDeadline = DateTime.MinValue;
+        // When each addon first became ready (DateTime.MinValue while it is closed). We only act
+        // once it has been ready for DialogueSettle, so we never click into an open transition.
+        var lotteryReadySince = DateTime.MinValue;
+        var yesNoReadySince = DateTime.MinValue;
+        var talkReadySince = DateTime.MinValue;
         return new FrameRunner.Step("DrainKupoCards",
             () =>
             {
@@ -102,6 +115,15 @@ public partial class KupoOfFortuneHandler
                 var talk = _window.IsTalkOpen;
                 var occupied = Svc.Condition[ConditionFlag.OccupiedInQuestEvent] ||
                                Svc.Condition[ConditionFlag.OccupiedInEvent];
+
+                // Track readiness onset per addon and derive "settled" gates. An addon must have
+                // been continuously ready for DialogueSettle before we fire its callback.
+                lotteryReadySince = lottery ? (lotteryReadySince == DateTime.MinValue ? now : lotteryReadySince) : DateTime.MinValue;
+                yesNoReadySince = yesNo ? (yesNoReadySince == DateTime.MinValue ? now : yesNoReadySince) : DateTime.MinValue;
+                talkReadySince = talk ? (talkReadySince == DateTime.MinValue ? now : talkReadySince) : DateTime.MinValue;
+                var lotterySettled = lottery && now - lotteryReadySince >= DialogueSettle;
+                var yesNoSettled = yesNo && now - yesNoReadySince >= DialogueSettle;
+                var talkSettled = talk && now - talkReadySince >= DialogueSettle;
 
                 // A lottery card open always means "go play it", regardless of phase.
                 if (lottery && phase != KupoPhase.Play)
@@ -128,7 +150,7 @@ public partial class KupoOfFortuneHandler
                         if (yesNo)
                         {
                             offerDeadline = now + OfferGrace;
-                            if (now >= nextAction)
+                            if (yesNoSettled && now >= nextAction)
                             {
                                 _window.ConfirmYesNo();
                                 nextAction = now + UiInteractDelay;
@@ -138,7 +160,7 @@ public partial class KupoOfFortuneHandler
                         if (talk)
                         {
                             offerDeadline = now + OfferGrace;
-                            if (now >= nextAction)
+                            if (talkSettled && now >= nextAction)
                             {
                                 _window.ProgressTalk();
                                 nextAction = now + UiInteractDelay;
@@ -156,6 +178,9 @@ public partial class KupoOfFortuneHandler
                         {
                             if (!cardScratched)
                             {
+                                // Don't scratch on the addon's first ready frame — same
+                                // open-transition hazard as the dialogue clicks.
+                                if (!lotterySettled) return StepResult.Continue();
                                 var chestIndex = PickChestIndex();
                                 _window.Scratch(chestIndex);
                                 Log.Debug($"Kupo of Fortune: scratching chest index {chestIndex} ({_configuration.KupoChestPick}).");
@@ -194,8 +219,8 @@ public partial class KupoOfFortuneHandler
                         {
                             if (now >= nextAction)
                             {
-                                if (!_window.ProgressTalk()) _window.ConfirmYesNo();
-                                nextAction = now + UiInteractDelay;
+                                if (talk && talkSettled) { _window.ProgressTalk(); nextAction = now + UiInteractDelay; }
+                                else if (yesNo && yesNoSettled) { _window.ConfirmYesNo(); nextAction = now + UiInteractDelay; }
                             }
                             return StepResult.Continue();
                         }

--- a/TheCollector/FirmamentManager/KupoOfFortuneHandler.Pipeline.cs
+++ b/TheCollector/FirmamentManager/KupoOfFortuneHandler.Pipeline.cs
@@ -14,9 +14,13 @@ public partial class KupoOfFortuneHandler
     // miscount can never spin the loop forever.
     private const int MaxCardsPerRun = 12;
 
-    private static readonly TimeSpan InteractInterval = TimeSpan.FromMilliseconds(700);
-    // Minimum dwell after scratching so the choice registers before we close the result.
-    private static readonly TimeSpan ScratchSettle = TimeSpan.FromMilliseconds(600);
+    // Delay between UI interactions, driven by the shared, user-configurable UI Delay setting
+    // (Configuration.UiDelayMs) just like every other automation here. Kupo previously used its
+    // own hardcoded 700ms/600ms timings and ignored this setting; routing it through UiDelayMs
+    // makes the pace consistent and tunable from the Settings tab.
+    private TimeSpan UiInteractDelay => TimeSpan.FromMilliseconds(_configuration.UiDelayMs);
+    // Dwell after scratching so the choice registers before we close the result.
+    private TimeSpan ScratchSettle => UiInteractDelay;
     // After interacting, how long to wait for a card to be offered before concluding there
     // are no vouchers left. The timer is held off while any dialogue/event is in progress.
     private static readonly TimeSpan OfferGrace = TimeSpan.FromSeconds(3);
@@ -110,7 +114,7 @@ public partial class KupoOfFortuneHandler
                         {
                             VNavmesh_IPCSubscriber.Path_Stop();
                             TryInteractWithLizbeth();
-                            nextAction = now + InteractInterval;
+                            nextAction = now + UiInteractDelay;
                             offerDeadline = now + OfferGrace;
                             phase = KupoPhase.AwaitOffer;
                         }
@@ -127,7 +131,7 @@ public partial class KupoOfFortuneHandler
                             if (now >= nextAction)
                             {
                                 _window.ConfirmYesNo();
-                                nextAction = now + InteractInterval;
+                                nextAction = now + UiInteractDelay;
                             }
                             return StepResult.Continue();
                         }
@@ -137,7 +141,7 @@ public partial class KupoOfFortuneHandler
                             if (now >= nextAction)
                             {
                                 _window.ProgressTalk();
-                                nextAction = now + InteractInterval;
+                                nextAction = now + UiInteractDelay;
                             }
                             return StepResult.Continue();
                         }
@@ -164,7 +168,7 @@ public partial class KupoOfFortuneHandler
                             if (now >= nextClose)
                             {
                                 _window.CloseLottery();
-                                nextClose = now + InteractInterval;
+                                nextClose = now + UiInteractDelay;
                             }
                             return StepResult.Continue();
                         }
@@ -191,7 +195,7 @@ public partial class KupoOfFortuneHandler
                             if (now >= nextAction)
                             {
                                 if (!_window.ProgressTalk()) _window.ConfirmYesNo();
-                                nextAction = now + InteractInterval;
+                                nextAction = now + UiInteractDelay;
                             }
                             return StepResult.Continue();
                         }

--- a/TheCollector/FirmamentManager/KupoOfFortuneHandler.Pipeline.cs
+++ b/TheCollector/FirmamentManager/KupoOfFortuneHandler.Pipeline.cs
@@ -152,7 +152,9 @@ public partial class KupoOfFortuneHandler
                         {
                             if (!cardScratched)
                             {
-                                _window.Scratch();
+                                var chestIndex = PickChestIndex();
+                                _window.Scratch(chestIndex);
+                                Log.Debug($"Kupo of Fortune: scratching chest index {chestIndex} ({_configuration.KupoChestPick}).");
                                 cardScratched = true;
                                 settleUntil = now + ScratchSettle;
                                 return StepResult.Continue();

--- a/TheCollector/FirmamentManager/KupoOfFortuneHandler.cs
+++ b/TheCollector/FirmamentManager/KupoOfFortuneHandler.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using Dalamud.Plugin.Services;
+using TheCollector.Data;
+using TheCollector.Utility;
+
+namespace TheCollector.FirmamentManager;
+
+// Plays the Kupo of Fortune scratch-card minigame at Lizbeth in The Firmament to drain
+// held cards before they cap (and start wasting vouchers). Firmament-only; the orchestrator
+// gates it on Configuration.KupoOfFortuneEnabled and the active scrip system.
+public partial class KupoOfFortuneHandler : FrameRunnerPipelineBase
+{
+    public override string Key => "kupo-of-fortune";
+
+    private readonly KupoOfFortuneWindowHandler _window;
+    private readonly FirmamentCatalog _catalog;
+    private readonly IClientState _clientState;
+    private readonly ITargetManager _targetManager;
+
+    // Raised on successful completion (cards drained or none to play). Failures/timeouts
+    // surface through the inherited OnError event instead; the orchestrator listens to both
+    // so the post-turn-in flow always resumes.
+    public event Action? OnFinishedPlaying;
+
+    public KupoOfFortuneHandler(
+        PlogonLog log,
+        KupoOfFortuneWindowHandler window,
+        FirmamentCatalog catalog,
+        IClientState clientState,
+        ITargetManager targetManager,
+        IFramework framework,
+        StatusService status) : base(log, framework, status)
+    {
+        _window = window;
+        _catalog = catalog;
+        _clientState = clientState;
+        _targetManager = targetManager;
+    }
+
+    private bool TryInteractWithLizbeth()
+        => _catalog.LizbethDataIds.Any(TryInteractWithNpc);
+}

--- a/TheCollector/FirmamentManager/KupoOfFortuneHandler.cs
+++ b/TheCollector/FirmamentManager/KupoOfFortuneHandler.cs
@@ -15,6 +15,7 @@ public partial class KupoOfFortuneHandler : FrameRunnerPipelineBase
 
     private readonly KupoOfFortuneWindowHandler _window;
     private readonly FirmamentCatalog _catalog;
+    private readonly Configuration _configuration;
     private readonly IClientState _clientState;
     private readonly ITargetManager _targetManager;
 
@@ -27,6 +28,7 @@ public partial class KupoOfFortuneHandler : FrameRunnerPipelineBase
         PlogonLog log,
         KupoOfFortuneWindowHandler window,
         FirmamentCatalog catalog,
+        Configuration config,
         IClientState clientState,
         ITargetManager targetManager,
         IFramework framework,
@@ -34,10 +36,17 @@ public partial class KupoOfFortuneHandler : FrameRunnerPipelineBase
     {
         _window = window;
         _catalog = catalog;
+        _configuration = config;
         _clientState = clientState;
         _targetManager = targetManager;
     }
 
     private bool TryInteractWithLizbeth()
         => _catalog.LizbethDataIds.Any(TryInteractWithNpc);
+
+    // Chest index to scratch for the next card, per the configured preference.
+    private int PickChestIndex()
+        => _configuration.KupoChestPick == KupoChestPick.RandomRight
+            ? KupoOfFortuneWindowHandler.RightChestIndices[Random.Shared.Next(KupoOfFortuneWindowHandler.RightChestIndices.Length)]
+            : KupoOfFortuneWindowHandler.LeftChestIndex;
 }

--- a/TheCollector/FirmamentManager/KupoOfFortuneWindowHandler.cs
+++ b/TheCollector/FirmamentManager/KupoOfFortuneWindowHandler.cs
@@ -1,0 +1,102 @@
+using ECommons;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.AtkValueType;
+
+namespace TheCollector.FirmamentManager;
+
+// Drives the "HWDLottery" addon — the Kupo of Fortune scratch card you play at Lizbeth.
+// Scratch a chest with the (0, 1) callback, then once the reward is shown and the Close
+// button (node id 36) is enabled, click it to claim and dismiss the card.
+public unsafe class KupoOfFortuneWindowHandler
+{
+    public const string AddonName = "HWDLottery";
+
+    // The Close/claim button on the lottery result view (node id 36), verified in-game via
+    // the addon dump. It only becomes enabled once a chest has been scratched and the reward
+    // is shown, so its enabled state is our "ready to close" signal.
+    private const int CloseButtonNodeIndex = 7;
+
+    public bool IsLotteryOpen =>
+        GenericHelpers.TryGetAddonByName<AtkUnitBase>(AddonName, out var addon) &&
+        GenericHelpers.IsAddonReady(addon);
+
+    public bool IsTalkOpen =>
+        GenericHelpers.TryGetAddonByName<AtkUnitBase>("Talk", out var addon) &&
+        GenericHelpers.IsAddonReady(addon);
+
+    public bool IsYesNoOpen =>
+        GenericHelpers.TryGetAddonByName<AtkUnitBase>("SelectYesno", out var addon) &&
+        GenericHelpers.IsAddonReady(addon);
+
+    public void Scratch()
+    {
+        if (!GenericHelpers.TryGetAddonByName<AtkUnitBase>(AddonName, out var addon) ||
+            !GenericHelpers.IsAddonReady(addon))
+            return;
+
+        var values = stackalloc AtkValue[2];
+        values[0] = new AtkValue { Type = ValueType.Int, Int = 0 };
+        values[1] = new AtkValue { Type = ValueType.Int, Int = 1 };
+        addon->FireCallback(2, values, true);
+    }
+
+    // True once the scratched chest's reward is shown and the close button is live — i.e.
+    // the card is finished and safe to claim/dismiss.
+    public bool IsRevealComplete
+    {
+        get
+        {
+            if (!GenericHelpers.TryGetAddonByName<AtkUnitBase>(AddonName, out var addon) ||
+                !GenericHelpers.IsAddonReady(addon))
+                return false;
+            var closeButton = GetCloseButton(addon);
+            return closeButton != null && closeButton->IsEnabled;
+        }
+    }
+
+    public bool CloseLottery()
+    {
+        if (!GenericHelpers.TryGetAddonByName<AtkUnitBase>(AddonName, out var addon) ||
+            !GenericHelpers.IsAddonReady(addon))
+            return false;
+
+        var closeButton = GetCloseButton(addon);
+        if (closeButton == null || !closeButton->IsEnabled)
+            return false;
+
+        // Click the result window's Close button (node id 36). The reward is already granted
+        // on scratch, so this just dismisses the display.
+        var eventData = new AtkEvent();
+        addon->ReceiveEvent(AtkEventType.ButtonClick, 0, &eventData);
+        return true;
+    }
+
+    private static AtkComponentButton* GetCloseButton(AtkUnitBase* addon)
+    {
+        if (addon->UldManager.NodeListCount <= CloseButtonNodeIndex)
+            return null;
+        var node = addon->UldManager.NodeList[CloseButtonNodeIndex];
+        return node == null ? null : node->GetAsAtkComponentButton();
+    }
+
+    // Lizbeth shows a one-page Talk dialogue and a yes/no confirmation before the lottery
+    // opens; reuse the same advance helpers the appraiser flow uses.
+    public bool ProgressTalk()
+    {
+        if (!GenericHelpers.TryGetAddonByName<AtkUnitBase>("Talk", out var addon) ||
+            !GenericHelpers.IsAddonReady(addon))
+            return false;
+        new ECommons.UIHelpers.AddonMasterImplementations.AddonMaster.Talk(addon).Click();
+        return true;
+    }
+
+    public bool ConfirmYesNo()
+    {
+        if (!GenericHelpers.TryGetAddonByName<AtkUnitBase>("SelectYesno", out var addon) ||
+            !GenericHelpers.IsAddonReady(addon))
+            return false;
+        new ECommons.UIHelpers.AddonMasterImplementations.AddonMaster.SelectYesno(addon).Yes();
+        return true;
+    }
+
+}

--- a/TheCollector/FirmamentManager/KupoOfFortuneWindowHandler.cs
+++ b/TheCollector/FirmamentManager/KupoOfFortuneWindowHandler.cs
@@ -5,11 +5,17 @@ using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.AtkValueType;
 namespace TheCollector.FirmamentManager;
 
 // Drives the "HWDLottery" addon — the Kupo of Fortune scratch card you play at Lizbeth.
-// Scratch a chest with the (0, 1) callback, then once the reward is shown and the Close
-// button (node id 36) is enabled, click it to claim and dismiss the card.
+// Scratch a chest with the (0, chestIndex) callback, then once the reward is shown and the
+// Close button (node id 36) is enabled, click it to claim and dismiss the card.
 public unsafe class KupoOfFortuneWindowHandler
 {
     public const string AddonName = "HWDLottery";
+
+    // Scratch-callback chest indices (second arg of the (0, index) callback). The card has one
+    // chest on the left and three on the right; the previously hard-coded index was 1 (a right
+    // chest). Confirm the left/right mapping in-game and swap these if it turns out inverted.
+    public const int LeftChestIndex = 0;
+    public static readonly int[] RightChestIndices = { 1, 2, 3 };
 
     // The Close/claim button on the lottery result view (node id 36), verified in-game via
     // the addon dump. It only becomes enabled once a chest has been scratched and the reward
@@ -28,7 +34,7 @@ public unsafe class KupoOfFortuneWindowHandler
         GenericHelpers.TryGetAddonByName<AtkUnitBase>("SelectYesno", out var addon) &&
         GenericHelpers.IsAddonReady(addon);
 
-    public void Scratch()
+    public void Scratch(int chestIndex)
     {
         if (!GenericHelpers.TryGetAddonByName<AtkUnitBase>(AddonName, out var addon) ||
             !GenericHelpers.IsAddonReady(addon))
@@ -36,7 +42,7 @@ public unsafe class KupoOfFortuneWindowHandler
 
         var values = stackalloc AtkValue[2];
         values[0] = new AtkValue { Type = ValueType.Int, Int = 0 };
-        values[1] = new AtkValue { Type = ValueType.Int, Int = 1 };
+        values[1] = new AtkValue { Type = ValueType.Int, Int = chestIndex };
         addon->FireCallback(2, values, true);
     }
 

--- a/TheCollector/Plugin.cs
+++ b/TheCollector/Plugin.cs
@@ -55,7 +55,7 @@ public sealed class Plugin : IDalamudPlugin
 
         CommandManager.AddHandler(CommandName, new CommandInfo(OnCommand)
         {
-            HelpMessage = "Opens the main UI. \n/collector config - Opens up the config UI\n/collector collect - Starts turning in collectables."
+            HelpMessage = "Opens the main UI. \n/collector config - Opens up the config UI\n/collector collect - Starts turning in collectables.\n/collector inspect - Runs the Skybuilders' resource inspection."
         });
 
         PluginInterface.UiBuilder.Draw += DrawUI;
@@ -115,6 +115,9 @@ public sealed class Plugin : IDalamudPlugin
         {
             case "collect":
                 _automationHandler.Invoke();
+                break;
+            case "inspect":
+                _automationHandler.InvokeInspection();
                 break;
             case "config":
                 ToggleConfigUI();

--- a/TheCollector/ResourceInspectionManager/ResourceInspectionHandler.Pipeline.cs
+++ b/TheCollector/ResourceInspectionManager/ResourceInspectionHandler.Pipeline.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using ECommons.GameHelpers;
+using TheCollector.Data;
+using TheCollector.FirmamentManager;
+using TheCollector.Ipc;
+using TheCollector.Utility;
+
+namespace TheCollector.ResourceInspectionManager;
+
+public partial class ResourceInspectionHandler
+{
+    private TimeSpan UiInteractDelay => TimeSpan.FromMilliseconds(_configuration.UiDelayMs);
+    // How long to wait for the server to apply an inspection (scrip/inventory change) before
+    // concluding the current job has no more eligible materials.
+    private static readonly TimeSpan ChangeTimeout = TimeSpan.FromSeconds(5);
+
+    private bool _firmamentRouteIssued;
+    private DateTime _nextInteract;
+    private int _jobCursor;
+    private int _currentSelectedTab;
+    private bool _jobMadeProgress;
+
+    protected override FrameRunner.Step[] BuildSteps()
+    {
+        CapReached = false;
+        LastEarnedCurrency = null;
+        _jobCursor = 0;
+        _currentSelectedTab = -1;
+        _jobMadeProgress = true; // don't skip the first job before it has had a cycle
+        var territoryId = _catalog.TerritoryId;
+
+        // No cheap pre-check for "do I have inspectable materials" — just go. If there's nothing,
+        // the per-job "resources available" flag (#76) makes the run a quick no-op.
+        return new[]
+        {
+            FrameRunner.Delay("InitialDelay", TimeSpan.FromSeconds(2)),
+            new FrameRunner.Step("CanActCheck",
+                () => PlayerEx.CanAct ? StepResult.Success() : StepResult.Continue(),
+                TimeSpan.FromSeconds(120)),
+            new FrameRunner.Step("RouteToFirmament",
+                () => MakeFirmamentRouteTick(territoryId),
+                TimeSpan.FromSeconds(120),
+                () => _firmamentRouteIssued = false),
+            new FrameRunner.Step("WaitLifestreamDone",
+                () => _lifestreamIpc.IsBusy() ? StepResult.Continue() : StepResult.Success(),
+                TimeSpan.FromSeconds(30)),
+            new FrameRunner.Step("WaitCanActAfterRoute",
+                () => PlayerEx.CanAct ? StepResult.Success() : StepResult.Continue(),
+                TimeSpan.FromSeconds(20)),
+            FrameRunner.Delay("PostRouteBuffer", TimeSpan.FromSeconds(2)),
+            new FrameRunner.Step("MoveToInspector",
+                MakeMoveToInspectorTick,
+                TimeSpan.FromSeconds(60),
+                ResetMoveThrottle),
+            new FrameRunner.Step("OpenInspector",
+                () =>
+                {
+                    if (_window.IsReady) return StepResult.Success();
+                    if (DateTime.UtcNow >= _nextInteract)
+                    {
+                        if (!_window.ProgressTalk())
+                        {
+                            VNavmesh_IPCSubscriber.Path_Stop();
+                            TryInteractWithNpc(InspectorBaseId);
+                        }
+                        _nextInteract = DateTime.UtcNow + TimeSpan.FromMilliseconds(700);
+                    }
+                    return StepResult.Continue();
+                },
+                TimeSpan.FromSeconds(15),
+                () => _nextInteract = DateTime.MinValue),
+            InspectionDriver(),
+            FrameRunner.Delay("PostInspectBuffer", TimeSpan.FromSeconds(1)),
+            new FrameRunner.Step("CloseInspector",
+                () => { _window.CloseWindow(); _targetManager.Target = null; return StepResult.Success(); },
+                TimeSpan.FromSeconds(5)),
+            FrameRunner.Delay("FinalDelay", TimeSpan.FromSeconds(1)),
+        };
+    }
+
+    protected override void OnFinished(bool ok)
+    {
+        base.OnFinished(ok);
+        if (ok) OnFinishedTurnIn?.Invoke();
+    }
+
+    protected override void OnCanceledOrFailed(string? error)
+    {
+        base.OnCanceledOrFailed(error);
+        VNavmesh_IPCSubscriber.Path_Stop();
+        _window.CloseWindow();
+    }
+
+    private bool ScripCapReached()
+        => _window.TryGetScripCount(_catalog.ScripItemId, out var cur) && cur >= (uint)_catalog.HoldingCap;
+
+    // Walk the job tabs; for each, repeatedly auto-submit + request inspection until that job
+    // stops yielding (no inventory/scrip change), then advance. Stops early if the scrip cap is
+    // hit so the orchestrator can run a buy cycle and resume.
+    private FrameRunner.Step InspectionDriver() => new(
+        "InspectionDriver",
+        ctx =>
+        {
+            Status.Set(PluginState.ExchangingItems);
+
+            if (ScripCapReached())
+            {
+                CapReached = true;
+                Log.Debug("Skybuilders' Scrip cap reached; pausing inspection for a buy cycle.");
+                return StepResult.Success();
+            }
+
+            // The previous cycle made no progress => the current job is exhausted; move on.
+            if (!_jobMadeProgress)
+            {
+                _jobCursor++;
+                _currentSelectedTab = -1;
+            }
+            _jobMadeProgress = false;
+
+            if (_jobCursor >= JobTabIndices.Length)
+                return StepResult.Success();
+
+            var tab = JobTabIndices[_jobCursor];
+            var steps = new List<FrameRunner.Step>();
+            if (_currentSelectedTab != tab)
+            {
+                steps.Add(SelectJobStep(tab));
+                _currentSelectedTab = tab;
+            }
+            steps.Add(InspectJobCycleStep());
+            steps.Add(InspectionDriver());
+            ctx.InjectNext(steps);
+            return StepResult.Success();
+        },
+        TimeSpan.FromSeconds(15));
+
+    private FrameRunner.Step SelectJobStep(int tab)
+        => FireAndSettle("SelectInspectionJob", () => _window.SelectJob(tab), UiInteractDelay, TimeSpan.FromSeconds(10));
+
+    private FrameRunner.Step InspectJobCycleStep()
+    {
+        var phase = 0;
+        uint scripBefore = 0;
+        DateTime until = default;
+        DateTime changeDeadline = default;
+        return new FrameRunner.Step("InspectJobCycle",
+            () =>
+            {
+                switch (phase)
+                {
+                    case 0:
+                        // Nothing left for this job -> let the driver advance to the next one.
+                        if (_window.TryReadState(out _, out _, out var available) && !available)
+                        {
+                            _jobMadeProgress = false;
+                            return StepResult.Success();
+                        }
+                        _window.TryGetScripCount(_catalog.ScripItemId, out scripBefore);
+                        _window.AutoSubmit();
+                        until = DateTime.UtcNow + UiInteractDelay;
+                        phase = 1;
+                        return StepResult.Continue();
+
+                    case 1:
+                        if (DateTime.UtcNow < until) return StepResult.Continue();
+                        // Auto-submit queued nothing -> job is effectively done.
+                        if (_window.TryReadState(out _, out var queued, out _) && queued <= 0)
+                        {
+                            _jobMadeProgress = false;
+                            return StepResult.Success();
+                        }
+                        _window.RequestInspection();
+                        until = DateTime.UtcNow + UiInteractDelay;
+                        changeDeadline = DateTime.UtcNow + ChangeTimeout;
+                        phase = 2;
+                        return StepResult.Continue();
+
+                    default:
+                        // Dismiss any confirmation, then wait for the trade to land.
+                        _window.ConfirmYesNo();
+                        if (DateTime.UtcNow < until) return StepResult.Continue();
+
+                        var creditedOrCleared = false;
+                        if (_window.TryGetScripCount(_catalog.ScripItemId, out var scripNow) && scripNow > scripBefore)
+                        {
+                            LastEarnedCurrency = _catalog.ScripItemId;
+                            OnScripsEarned?.Invoke(_catalog.ScripItemId, (int)(scripNow - scripBefore));
+                            creditedOrCleared = true;
+                        }
+                        // The queue resets to 0 once the inspection is applied.
+                        if (_window.TryReadState(out _, out var queuedAfter, out _) && queuedAfter == 0)
+                            creditedOrCleared = true;
+
+                        if (creditedOrCleared)
+                        {
+                            // Submitted a batch; keep going. The next cycle's "resources
+                            // available" check terminates the job when it runs dry.
+                            _jobMadeProgress = true;
+                            return StepResult.Success();
+                        }
+
+                        if (DateTime.UtcNow < changeDeadline) return StepResult.Continue();
+                        // Assume the batch went through even if we couldn't observe a delta
+                        // (e.g. at the scrip cap); let the next cycle re-evaluate.
+                        _jobMadeProgress = true;
+                        return StepResult.Success();
+                }
+            },
+            TimeSpan.FromSeconds(30));
+    }
+
+    private StepResult MakeFirmamentRouteTick(uint territoryId)
+        => FirmamentRouting.RouteTick(_clientState, _lifestreamIpc, Status, territoryId, ref _firmamentRouteIssued);
+
+    private StepResult MakeMoveToInspectorTick()
+    {
+        Status.Set(PluginState.MovingToCollectableVendor, "to the Resource Inspector");
+        return MoveTowardsTick(FirmamentRouting.LivePosition(new[] { InspectorBaseId }, InspectorPosition));
+    }
+}

--- a/TheCollector/ResourceInspectionManager/ResourceInspectionHandler.cs
+++ b/TheCollector/ResourceInspectionManager/ResourceInspectionHandler.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Numerics;
+using Dalamud.Plugin.Services;
+using TheCollector.Data;
+using TheCollector.Data.ScripSystem;
+using TheCollector.Ipc;
+using TheCollector.Utility;
+
+namespace TheCollector.ResourceInspectionManager;
+
+// Turn-in pipeline for the Skybuilders' Resource Inspection at Flotpassant the Resource
+// Inspector. Implements ITurnInPipeline so it slots into AutomationHandler's existing
+// turn-in -> (scrip cap) -> buy -> turn-in loop, paired with the Firmament shop buy.
+public partial class ResourceInspectionHandler : FrameRunnerPipelineBase, ITurnInPipeline
+{
+    public override string Key => "resource-inspection";
+
+    private readonly ResourceInspectionWindowHandler _window;
+    private readonly FirmamentCatalog _catalog;
+    private readonly Configuration _configuration;
+    private readonly ITargetManager _targetManager;
+    private readonly IClientState _clientState;
+    private readonly IDataManager _dataManager;
+    private readonly Lifestream_IPCSubscriber _lifestreamIpc;
+
+    public event Action? OnFinishedTurnIn;
+    public event Action<uint, int>? OnScripsEarned;
+
+    event Action ITurnInPipeline.OnFinished
+    {
+        add => OnFinishedTurnIn += value;
+        remove => OnFinishedTurnIn -= value;
+    }
+
+    public ResourceInspectionHandler(
+        PlogonLog log,
+        ResourceInspectionWindowHandler window,
+        FirmamentCatalog catalog,
+        Configuration config,
+        ITargetManager targetManager,
+        IFramework framework,
+        IClientState clientState,
+        IDataManager dataManager,
+        Lifestream_IPCSubscriber lifestreamIpc,
+        StatusService status) : base(log, framework, status)
+    {
+        _window = window;
+        _catalog = catalog;
+        _configuration = config;
+        _targetManager = targetManager;
+        _clientState = clientState;
+        _dataManager = dataManager;
+        _lifestreamIpc = lifestreamIpc;
+    }
+
+    public uint? LastEarnedCurrency { get; private set; }
+    public bool CapReached { get; private set; }
+
+    // There's no cheap way to know which gathered items are inspectable without opening the
+    // window (the HWDGathererInspection sheet only lists Heavensward-era items). So we always
+    // consider it worth a run; the window's per-job "resources available" flag (#76) makes the
+    // run a fast no-op when nothing is left, and stops the post-buy resume loop.
+    public bool HasCollectible => true;
+
+    // Flotpassant the Resource Inspector, in The Firmament.
+    private const uint InspectorBaseId = 1031693;
+    private static readonly Vector3 InspectorPosition = new(-21.25586f, -16f, 138.93335f);
+
+    // In-window job tabs (Miner / Botanist / Fisher).
+    private static readonly int[] JobTabIndices = { 0, 1, 2 };
+}

--- a/TheCollector/ResourceInspectionManager/ResourceInspectionWindowHandler.cs
+++ b/TheCollector/ResourceInspectionManager/ResourceInspectionWindowHandler.cs
@@ -1,0 +1,131 @@
+using ECommons;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using TheCollector.Utility;
+using ValueType = FFXIVClientStructs.FFXIV.Component.GUI.AtkValueType;
+
+namespace TheCollector.ResourceInspectionManager;
+
+// Wrapper over the Skybuilders' "Resource Control" addon shown when talking to Flotpassant
+// (the Resource Inspector). Modeled on FirmamentTurnInWindowHandler.
+//
+// IMPORTANT — in-game discovery required: the addon's internal name and the FireCallback
+// argument layouts below are best guesses and MUST be confirmed in-game with Dalamud's addon
+// inspector (the Firmament HWDSupply callbacks were found the same way). All such magic values
+// are confined to this file. The pipeline deliberately detects per-job exhaustion and progress
+// via inventory/scrip deltas instead of node reads, so only these callbacks need verifying.
+public unsafe class ResourceInspectionWindowHandler
+{
+    // Confirmed in-game: the Resource Control window's addon.
+    public const string AddonName = "HWDGathereInspect";
+
+    // Confirmed in-game via /collector inspectdebug.
+    private const int CaseSelectJob = 14;        // arg1 (UInt) = job tab index (0=MIN, 1=BTN, 2=FSH)
+    private const int CaseAutoSubmit = 12;        // auto-select up to five eligible items
+    private const int CaseRequestInspection = 11; // submit the queued items for inspection
+
+    private readonly PlogonLog _log;
+
+    public ResourceInspectionWindowHandler(PlogonLog log) => _log = log;
+
+    private bool TryGetAddon(out AtkUnitBase* addon)
+    {
+        addon = null;
+        if (GenericHelpers.TryGetAddonByName<AtkUnitBase>(AddonName, out var a) &&
+            GenericHelpers.IsAddonReady(a))
+        {
+            addon = a;
+            return true;
+        }
+        return false;
+    }
+
+    public bool IsReady => TryGetAddon(out _);
+
+    // Live window state, decoded from the addon's AtkValues (see
+    // images/resource-inspection-atkvalues.txt):
+    //   [1]          = selected gathering job (0 = Miner, 1 = Botanist, 2 = Fisher)
+    //   [count - 4]  = number of materials currently queued for inspection (0..5)
+    //   [count - 1]  = "resources available" — false once the selected job has nothing left
+    // The item list between them is variable-length, so the summary fields are read relative
+    // to AtkValuesCount rather than at fixed indices.
+    public bool TryReadState(out int selectedJob, out int queuedCount, out bool resourcesAvailable)
+    {
+        selectedJob = -1;
+        queuedCount = 0;
+        resourcesAvailable = false;
+        if (!TryGetAddon(out var addon)) return false;
+        var count = (int)addon->AtkValuesCount;
+        var v = addon->AtkValues;
+        if (v == null || count < 7) return false;
+
+        if (v[1].Type == ValueType.UInt) selectedJob = (int)v[1].UInt;
+        var queued = v[count - 4];
+        if (queued.Type == ValueType.UInt) queuedCount = (int)queued.UInt;
+        resourcesAvailable = v[count - 1].Byte != 0;
+        return true;
+    }
+
+    public void SelectJob(int jobTabIndex)
+    {
+        if (!TryGetAddon(out var addon)) return;
+        var values = stackalloc AtkValue[2];
+        values[0] = new AtkValue { Type = ValueType.Int, Int = CaseSelectJob };
+        values[1] = new AtkValue { Type = ValueType.UInt, UInt = (uint)jobTabIndex };
+        addon->FireCallback(2, values, true);
+    }
+
+    public bool AutoSubmit()
+    {
+        if (!TryGetAddon(out var addon)) return false;
+        var values = stackalloc AtkValue[1];
+        values[0] = new AtkValue { Type = ValueType.Int, Int = CaseAutoSubmit };
+        addon->FireCallback(1, values, true);
+        return true;
+    }
+
+    public bool RequestInspection()
+    {
+        if (!TryGetAddon(out var addon)) return false;
+        var values = stackalloc AtkValue[1];
+        values[0] = new AtkValue { Type = ValueType.Int, Int = CaseRequestInspection };
+        addon->FireCallback(1, values, true);
+        return true;
+    }
+
+    // Advance a one-page Talk dialogue Flotpassant may show before the window opens.
+    public bool ProgressTalk()
+    {
+        if (!GenericHelpers.TryGetAddonByName<AtkUnitBase>("Talk", out var addon) ||
+            !GenericHelpers.IsAddonReady(addon))
+            return false;
+        new ECommons.UIHelpers.AddonMasterImplementations.AddonMaster.Talk(addon).Click();
+        return true;
+    }
+
+    // Confirmation popup that may appear after Request Inspection.
+    public bool ConfirmYesNo()
+    {
+        if (!GenericHelpers.TryGetAddonByName<AtkUnitBase>("SelectYesno", out var addon) ||
+            !GenericHelpers.IsAddonReady(addon))
+            return false;
+        new ECommons.UIHelpers.AddonMasterImplementations.AddonMaster.SelectYesno(addon).Yes();
+        return true;
+    }
+
+    public bool TryGetScripCount(uint scripItemId, out uint count)
+    {
+        count = 0;
+        var cur = CurrencyManager.Instance();
+        if (cur == null) return false;
+        count = cur->GetItemCount(scripItemId);
+        return true;
+    }
+
+    public void CloseWindow()
+    {
+        if (GenericHelpers.TryGetAddonByName<AtkUnitBase>(AddonName, out var addon) &&
+            GenericHelpers.IsAddonReady(addon))
+            addon->Close(true);
+    }
+}

--- a/TheCollector/Utility/ArtisanWatcher.cs
+++ b/TheCollector/Utility/ArtisanWatcher.cs
@@ -20,6 +20,7 @@ public class ArtisanWatcher : IDisposable
     private readonly Configuration _configuration;
     private readonly PlogonLog _log;
     private readonly FirmamentCatalog _firmamentCatalog;
+    private readonly StatusService _status;
     public event Action<WatchType>? OnCraftingFinished;
     public event Action? OnInventoryFullDuringCrafting;
     public int PollInterval { get; set; } = 250;
@@ -31,13 +32,14 @@ public class ArtisanWatcher : IDisposable
     private bool InFirmament => _firmamentCatalog.TerritoryId != 0
                                && Svc.ClientState.TerritoryType == _firmamentCatalog.TerritoryId;
 
-    public ArtisanWatcher(IFramework framework, Artisan_IPCSubscriber artisanIpc, Configuration config, PlogonLog log, FirmamentCatalog firmamentCatalog)
+    public ArtisanWatcher(IFramework framework, Artisan_IPCSubscriber artisanIpc, Configuration config, PlogonLog log, FirmamentCatalog firmamentCatalog, StatusService status)
     {
         _framework = framework;
         ArtisanIpc = artisanIpc;
         _configuration = config;
         _log = log;
         _firmamentCatalog = firmamentCatalog;
+        _status = status;
         Init();
     }
 
@@ -86,7 +88,25 @@ public class ArtisanWatcher : IDisposable
             OnInventoryFullDuringCrafting?.Invoke();
         }
 
+        UpdateCraftingStatus(isCrafting);
         _wasCrafting = isCrafting;
+    }
+
+    // Surface a dedicated status while a list crafts. Only ever toggle between Idle and
+    // our own state so we never clobber a status a turn-in/buy pipeline currently owns.
+    // (During our own inventory-full pause we return early above, leaving status to the
+    // turn-in pipeline.)
+    private void UpdateCraftingStatus(bool isCrafting)
+    {
+        if (isCrafting)
+        {
+            if (_status.Current == PluginState.Idle)
+                _status.Set(PluginState.ProcessingArtisanList);
+        }
+        else if (_status.Current == PluginState.ProcessingArtisanList)
+        {
+            _status.SetIdle();
+        }
     }
 
     private bool ShouldPauseForInventory()

--- a/TheCollector/Utility/ArtisanWatcher.cs
+++ b/TheCollector/Utility/ArtisanWatcher.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using Dalamud.Plugin.Services;
+using ECommons.DalamudServices;
 using TheCollector.Data;
 using TheCollector.Ipc;
 
@@ -18,17 +19,25 @@ public class ArtisanWatcher : IDisposable
     private DateTime _suppressUntil = DateTime.MinValue;
     private readonly Configuration _configuration;
     private readonly PlogonLog _log;
+    private readonly FirmamentCatalog _firmamentCatalog;
     public event Action<WatchType>? OnCraftingFinished;
     public event Action? OnInventoryFullDuringCrafting;
     public int PollInterval { get; set; } = 250;
     public bool IsPausedByUs => _pausedByUs;
 
-    public ArtisanWatcher(IFramework framework, Artisan_IPCSubscriber artisanIpc, Configuration config, PlogonLog log)
+    // The Firmament reports as a duty (its territory intended-use isn't Open World/City),
+    // so the bare IsInDuty guard would silence the watcher there. Mirror the exception
+    // AutomationHandler.Invoke() already makes for the Firmament territory.
+    private bool InFirmament => _firmamentCatalog.TerritoryId != 0
+                               && Svc.ClientState.TerritoryType == _firmamentCatalog.TerritoryId;
+
+    public ArtisanWatcher(IFramework framework, Artisan_IPCSubscriber artisanIpc, Configuration config, PlogonLog log, FirmamentCatalog firmamentCatalog)
     {
         _framework = framework;
         ArtisanIpc = artisanIpc;
         _configuration = config;
         _log = log;
+        _firmamentCatalog = firmamentCatalog;
         Init();
     }
 
@@ -44,7 +53,7 @@ public class ArtisanWatcher : IDisposable
             return;
 
         UpdateWatch.Restart();
-        if (PlayerEx.IsInDuty)
+        if (PlayerEx.IsInDuty && !InFirmament)
             return;
 
         if (_pausedByUs)

--- a/TheCollector/Utility/FirmamentCatalog.cs
+++ b/TheCollector/Utility/FirmamentCatalog.cs
@@ -29,6 +29,7 @@ public sealed class FirmamentCatalog
 
     public IReadOnlyList<Placement> Appraisers { get; private set; } = Array.Empty<Placement>();
     public IReadOnlyList<Placement> Exchanges { get; private set; } = Array.Empty<Placement>();
+    public IReadOnlyList<Placement> Lizbeths { get; private set; } = Array.Empty<Placement>();
     public IReadOnlySet<uint> TurnInItemIds { get; private set; } = new HashSet<uint>();
     public IReadOnlyDictionary<uint, int> CrafterJobByItemId { get; private set; } = new Dictionary<uint, int>();
     public IReadOnlyList<FirmamentWare> Wares { get; private set; } = Array.Empty<FirmamentWare>();
@@ -67,8 +68,12 @@ public sealed class FirmamentCatalog
 
     public uint[] AppraiserDataIds => Appraisers.Select(p => p.DataId).ToArray();
     public uint[] ExchangeDataIds => Exchanges.Select(p => p.DataId).ToArray();
+    public uint[] LizbethDataIds => Lizbeths.Select(p => p.DataId).ToArray();
     public Vector3 AppraiserPosition => Appraisers.Count > 0 ? Appraisers[0].Position : Vector3.Zero;
     public Vector3 ExchangePosition => Exchanges.Count > 0 ? Exchanges[0].Position : Vector3.Zero;
+    // Lizbeth stands next to the appraiser; fall back to the appraiser spot if her
+    // placement could not be resolved so movement still lands in the right area.
+    public Vector3 LizbethPosition => Lizbeths.Count > 0 ? Lizbeths[0].Position : AppraiserPosition;
 
     public FirmamentCatalog(PlogonLog log)
     {
@@ -107,8 +112,13 @@ public sealed class FirmamentCatalog
             if (npc.ENpcData.Any(e => e.RowId == FirmamentAnchors.ExchangeTalkId)) exchangeNpcIds.Add(npc.RowId);
         }
 
+        var lizbethNpcIds = FirmamentAnchors.LizbethNpcIds.ToHashSet();
+
         var appraisers = new List<Placement>();
         var exchanges = new List<Placement>();
+        // Several NPCs share the name "Lizbeth"; keep each candidate with its territory so
+        // we can pick the one in the Firmament once the territory is resolved below.
+        var lizbethCandidates = new List<(Placement placement, uint territory)>();
         var territoryVotes = new Dictionary<uint, int>();
         foreach (var lv in levelSheet)
         {
@@ -123,11 +133,23 @@ public sealed class FirmamentCatalog
             }
             if (exchangeNpcIds.Contains(npcId))
                 exchanges.Add(new Placement(npcId, pos));
+            if (lizbethNpcIds.Contains(npcId))
+                lizbethCandidates.Add((new Placement(npcId, pos), lv.Territory.RowId));
         }
 
         TerritoryId = territoryVotes.Count > 0
             ? territoryVotes.OrderByDescending(kv => kv.Value).First().Key
             : 0;
+
+        var lizbeths = lizbethCandidates
+            .Where(c => TerritoryId != 0 && c.territory == TerritoryId)
+            .Select(c => c.placement)
+            .ToList();
+
+        // Pin the in-game-confirmed Lizbeth first, with her verified position, so movement
+        // and interaction always have a working anchor even if the scan above came up empty.
+        lizbeths.RemoveAll(p => p.DataId == FirmamentAnchors.LizbethNpcId);
+        lizbeths.Insert(0, new Placement(FirmamentAnchors.LizbethNpcId, FirmamentAnchors.LizbethPosition));
 
         var turnInItems = new HashSet<uint>();
         foreach (var row in crafterSheet)
@@ -177,6 +199,7 @@ public sealed class FirmamentCatalog
 
         Appraisers = appraisers;
         Exchanges = exchanges;
+        Lizbeths = lizbeths;
         TurnInItemIds = turnInItems;
         CrafterJobByItemId = jobByItem;
         Wares = wares;
@@ -184,6 +207,6 @@ public sealed class FirmamentCatalog
         _shopOrder = wares.Select(w => w.ShopId).Where(s => s != 0).Distinct().OrderBy(s => s).ToList();
 
         _log.Debug($"FirmamentCatalog: territory={TerritoryId} cap={HoldingCap} appraisers={appraisers.Count} " +
-                   $"exchanges={exchanges.Count} turnInItems={turnInItems.Count} wares={wares.Count}.");
+                   $"exchanges={exchanges.Count} lizbeths={lizbeths.Count} turnInItems={turnInItems.Count} wares={wares.Count}.");
     }
 }

--- a/TheCollector/Utility/ServiceWrapper.cs
+++ b/TheCollector/Utility/ServiceWrapper.cs
@@ -65,8 +65,13 @@ public static class ServiceWrapper
         collection.AddSingleton<FirmamentManager.FirmamentShopHandler>();
         collection.AddSingleton<IPipeline>(sp => sp.GetRequiredService<FirmamentManager.FirmamentShopHandler>());
 
+        collection.AddSingleton<ResourceInspectionManager.ResourceInspectionWindowHandler>();
+        collection.AddSingleton<ResourceInspectionManager.ResourceInspectionHandler>();
+        collection.AddSingleton<IPipeline>(sp => sp.GetRequiredService<ResourceInspectionManager.ResourceInspectionHandler>());
+
         collection.AddSingleton<Data.ScripSystem.NormalScripSystem>();
         collection.AddSingleton<Data.ScripSystem.FirmamentScripSystem>();
+        collection.AddSingleton<Data.ScripSystem.ResourceInspectionScripSystem>();
         collection.AddSingleton<Data.ScripSystem.ScripSystemSelector>();
         collection.AddSingleton<ScripShopItemManager>();
         collection.AddSingleton<CraftingHandler>();

--- a/TheCollector/Utility/ServiceWrapper.cs
+++ b/TheCollector/Utility/ServiceWrapper.cs
@@ -65,6 +65,10 @@ public static class ServiceWrapper
         collection.AddSingleton<FirmamentManager.FirmamentShopHandler>();
         collection.AddSingleton<IPipeline>(sp => sp.GetRequiredService<FirmamentManager.FirmamentShopHandler>());
 
+        collection.AddSingleton<FirmamentManager.KupoOfFortuneWindowHandler>();
+        collection.AddSingleton<FirmamentManager.KupoOfFortuneHandler>();
+        collection.AddSingleton<IPipeline>(sp => sp.GetRequiredService<FirmamentManager.KupoOfFortuneHandler>());
+
         collection.AddSingleton<Data.ScripSystem.NormalScripSystem>();
         collection.AddSingleton<Data.ScripSystem.FirmamentScripSystem>();
         collection.AddSingleton<Data.ScripSystem.ScripSystemSelector>();

--- a/TheCollector/Windows/MainWindow.Main.cs
+++ b/TheCollector/Windows/MainWindow.Main.cs
@@ -14,7 +14,7 @@ public partial class MainWindow
 {
     private void DrawMainTab()
     {
-        if (configuration.ActiveSystem == ScripSystemId.Firmament)
+        if (configuration.ActiveSystem.IsFirmamentLike())
         {
             DrawFirmamentMainTab();
             return;

--- a/TheCollector/Windows/MainWindow.Planner.cs
+++ b/TheCollector/Windows/MainWindow.Planner.cs
@@ -313,6 +313,7 @@ public partial class MainWindow
             {
                 ImGui.TextUnformatted($"Turn-ins:    {_automationHandler.SessionCollectablesTurnedIn}");
                 ImGui.TextUnformatted($"Buy cycles:  {_automationHandler.SessionItemsPurchased}");
+                ImGui.TextUnformatted($"Full loops:  {_automationHandler.SessionFullLoops}");
                 ImGui.TextUnformatted($"Scrips earned: {_automationHandler.SessionScripsEarnedTotal:N0}");
 
                 if (_automationHandler.SessionScripsEarned.Count > 0)

--- a/TheCollector/Windows/MainWindow.Settings.cs
+++ b/TheCollector/Windows/MainWindow.Settings.cs
@@ -273,12 +273,13 @@ public partial class MainWindow
         sb.AppendLine($"Stop when complete:    {configuration.Goal.StopGatheringWhenComplete}");
         sb.AppendLine($"Autogather on finish:  {configuration.EnableAutogatherOnFinish}");
         sb.AppendLine($"Collect on craft/fish/gather: {configuration.CollectOnFinishCraftingList}/{configuration.CollectOnFinishedFishing}/{configuration.CollectOnAutogatherFinish}");
-        sb.AppendLine($"Craft on autogather:   {configuration.ShouldCraftOnAutogatherChanged} (Artisan list {configuration.ArtisanListId})");
+        sb.AppendLine($"Inspect on gather:     {configuration.RunInspectionOnAutogatherFinish}");
+        sb.AppendLine($"Craft on inspection:   {configuration.CraftOnInspectionFinish} (Artisan list {configuration.ArtisanListId})");
         sb.AppendLine($"Artisan inv pause:     {configuration.PauseArtisanOnInventoryFull} (threshold {configuration.ArtisanInventoryFullThreshold})");
         sb.AppendLine($"AutoRetainer between:  {configuration.CheckForVenturesBetweenRuns}");
         sb.AppendLine($"Deliveroo between:     {configuration.CheckForDeliverooBetweenRuns}");
         var stop = configuration.Stop;
-        sb.AppendLine($"Stop conditions:       scrips={stop.StopOnScripsEarnedEnabled}({stop.MaxScripsEarned}) cycles={stop.StopOnBuyCyclesEnabled}({stop.MaxBuyCycles}) time={stop.StopOnSessionTimeEnabled}({stop.MaxSessionMinutes}m)");
+        sb.AppendLine($"Stop conditions:       scrips={stop.StopOnScripsEarnedEnabled}({stop.MaxScripsEarned}) cycles={stop.StopOnBuyCyclesEnabled}({stop.MaxBuyCycles}) time={stop.StopOnSessionTimeEnabled}({stop.MaxSessionMinutes}m) loops={stop.StopOnFullLoopsEnabled}({stop.MaxFullLoops})");
 
         sb.AppendLine();
         sb.AppendLine("[Catalogs]");
@@ -365,16 +366,31 @@ public partial class MainWindow
         if (!gbrReady && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
             ImGui.SetTooltip("GatherbuddyReborn is not installed or not ready.");
 
-        bool craftOnAutogatherActive = configuration.ShouldCraftOnAutogatherChanged;
-        ImGui.BeginDisabled(craftOnAutogatherActive);
+        // Two mutually-exclusive actions to take when autogather finishes.
+        bool inspectOnAutogatherActive = configuration.RunInspectionOnAutogatherFinish;
+        ImGui.BeginDisabled(inspectOnAutogatherActive);
         var collectOnAutogather = configuration.CollectOnAutogatherFinish;
         if (ImGui.Checkbox("Turn in collectables on autogather finish", ref collectOnAutogather))
         {
             configuration.CollectOnAutogatherFinish = collectOnAutogather;
             configuration.Save();
         }
-        if (craftOnAutogatherActive && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-            ImGui.SetTooltip("Disabled while \"Craft selected Artisan list on autogather finish\" is enabled (Artisan section).");
+        if (inspectOnAutogatherActive && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+            ImGui.SetTooltip("Disabled while \"Run resource inspection on autogather finish\" is enabled.");
+        else if (!gbrReady && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+            ImGui.SetTooltip("GatherbuddyReborn is not installed or not ready.");
+        ImGui.EndDisabled();
+
+        bool collectOnAutogatherActive = configuration.CollectOnAutogatherFinish;
+        ImGui.BeginDisabled(collectOnAutogatherActive);
+        var inspectOnAutogather = configuration.RunInspectionOnAutogatherFinish;
+        if (ImGui.Checkbox("Run resource inspection on autogather finish", ref inspectOnAutogather))
+        {
+            configuration.RunInspectionOnAutogatherFinish = inspectOnAutogather;
+            configuration.Save();
+        }
+        if (collectOnAutogatherActive && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+            ImGui.SetTooltip("Disabled while \"Turn in collectables on autogather finish\" is enabled.");
         else if (!gbrReady && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
             ImGui.SetTooltip("GatherbuddyReborn is not installed or not ready.");
         ImGui.EndDisabled();
@@ -397,21 +413,19 @@ public partial class MainWindow
 
         ImGui.BeginDisabled(!artisanSectionReady);
 
-        bool collectOnAutogatherActiveArtisan = configuration.CollectOnAutogatherFinish;
-        ImGui.BeginDisabled(collectOnAutogatherActiveArtisan);
-        var craftOnAutogather = configuration.ShouldCraftOnAutogatherChanged;
-        if (ImGui.Checkbox("Craft selected Artisan list on autogather finish", ref craftOnAutogather))
+        var craftOnInspection = configuration.CraftOnInspectionFinish;
+        if (ImGui.Checkbox("Craft selected Artisan list on resource inspection finish", ref craftOnInspection))
         {
-            configuration.ShouldCraftOnAutogatherChanged = craftOnAutogather;
+            configuration.CraftOnInspectionFinish = craftOnInspection;
             configuration.Save();
         }
-        if (collectOnAutogatherActiveArtisan && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-            ImGui.SetTooltip("Disabled while \"Turn in collectables on autogather finish\" is enabled (GatherBuddyReborn section).");
-        else if (artisanDisabledReason != null && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
+        if (artisanDisabledReason != null && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
             ImGui.SetTooltip(artisanDisabledReason);
-        ImGui.EndDisabled();
+        else if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("After a resource-inspection run finishes (gather → inspect → craft),\n" +
+                             "start the selected Artisan list.");
 
-        ImGui.BeginDisabled(!craftOnAutogather);
+        ImGui.BeginDisabled(!craftOnInspection);
 
         DrawArtisanListPicker();
 
@@ -685,6 +699,18 @@ public partial class MainWindow
                 configuration.Save();
             }
         }
+        {
+            var en = configuration.Stop.StopOnFullLoopsEnabled;
+            var v  = configuration.Stop.MaxFullLoops;
+            if (DrawStopConditionRow("Stop after full loops", ref en, ref v, 1, 1000, 1,
+                "One full loop = a complete gather → inspect → craft cycle, counted when\n" +
+                "autogather is re-enabled. Stops after finishing the current cycle."))
+            {
+                configuration.Stop.StopOnFullLoopsEnabled = en;
+                configuration.Stop.MaxFullLoops = v;
+                configuration.Save();
+            }
+        }
 
         ImGui.Spacing();
         ImGuiHelper.SectionHeader("Planner");
@@ -738,6 +764,7 @@ public partial class MainWindow
         var scripShop     = ServiceWrapper.Get<ScripShopAutomationHandler>();
         var retainer      = ServiceWrapper.Get<AutoRetainerManager>();
         var deliveroo     = ServiceWrapper.Get<DeliverooManager>();
+        var inspection    = ServiceWrapper.Get<ResourceInspectionManager.ResourceInspectionHandler>();
         var vendorCatalog = ServiceWrapper.Get<VendorCatalog>();
 
         ImGuiHelper.SectionHeader("State");
@@ -774,6 +801,7 @@ public partial class MainWindow
             Row("Session started",    _automationHandler.SessionStarted?.ToLocalTime().ToString("HH:mm:ss") ?? "-");
             Row("Turn-ins",           _automationHandler.SessionCollectablesTurnedIn.ToString());
             Row("Items purchased",    _automationHandler.SessionItemsPurchased.ToString());
+            Row("Full loops",         _automationHandler.SessionFullLoops.ToString());
             Row("Scrips earned",      _automationHandler.SessionScripsEarnedTotal.ToString());
             Row("Current item",       collectable.CurrentItemName ?? "-");
 
@@ -806,6 +834,8 @@ public partial class MainWindow
         if (ImGui.Button("Start autoretainer")) retainer.Start();
         ImGui.SameLine();
         if (ImGui.Button("Start deliveroo")) deliveroo.Start();
+        ImGui.SameLine();
+        if (ImGui.Button("Start resource inspection")) inspection.Start();
 
         if (ImGui.Button("Force stop all"))
             _automationHandler.ForceStop("Stopped from debug panel");
@@ -902,6 +932,7 @@ public partial class MainWindow
         {
             nameof(AutomationHandler.SessionCollectablesTurnedIn),
             nameof(AutomationHandler.SessionItemsPurchased),
+            nameof(AutomationHandler.SessionFullLoops),
         })
             t.GetProperty(name)?.GetSetMethod(nonPublic: true)?.Invoke(_automationHandler, new object[] { 0 });
 

--- a/TheCollector/Windows/MainWindow.Settings.cs
+++ b/TheCollector/Windows/MainWindow.Settings.cs
@@ -156,6 +156,35 @@ public partial class MainWindow
 
             ImGui.Spacing();
         }
+        else
+        {
+            ImGuiHelper.SectionHeader("Kupo of Fortune");
+
+            var kupoEnabled = configuration.KupoOfFortuneEnabled;
+            if (ImGui.Checkbox("Play Kupo of Fortune to spend held cards", ref kupoEnabled))
+            {
+                configuration.KupoOfFortuneEnabled = kupoEnabled;
+                configuration.Save();
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("After a Firmament turn-in, walk to Lizbeth and play any Kupo of Fortune\n" +
+                                 "cards you hold so vouchers earned past the 10-card cap aren't wasted.");
+
+            ImGui.BeginDisabled(!kupoEnabled);
+            ImGui.AlignTextToFramePadding();
+            ImGui.TextUnformatted("Play when cards held reach:");
+            ImGui.SameLine();
+            var threshold = configuration.KupoOfFortuneThreshold;
+            ImGui.SetNextItemWidth(-1);
+            if (ImGui.SliderInt("##KupoThreshold", ref threshold, 1, 10))
+            {
+                configuration.KupoOfFortuneThreshold = Math.Clamp(threshold, 1, 10);
+                configuration.Save();
+            }
+            ImGui.EndDisabled();
+
+            ImGui.Spacing();
+        }
 
         ImGuiHelper.SectionHeader("Automation");
 
@@ -806,6 +835,11 @@ public partial class MainWindow
         if (ImGui.Button("Start autoretainer")) retainer.Start();
         ImGui.SameLine();
         if (ImGui.Button("Start deliveroo")) deliveroo.Start();
+
+        if (ImGui.Button("Start Kupo of Fortune")) _automationHandler.InvokeKupo();
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Walk to Lizbeth in the Firmament and play any held Kupo of Fortune\n" +
+                             "cards. Runs standalone — won't trigger the buy/cascade flow.");
 
         if (ImGui.Button("Force stop all"))
             _automationHandler.ForceStop("Stopped from debug panel");

--- a/TheCollector/Windows/MainWindow.Settings.cs
+++ b/TheCollector/Windows/MainWindow.Settings.cs
@@ -181,6 +181,31 @@ public partial class MainWindow
                 configuration.KupoOfFortuneThreshold = Math.Clamp(threshold, 1, 10);
                 configuration.Save();
             }
+
+            const string leftLabel = "Left chest (2nd-4th prizes)";
+            const string rightLabel = "Random right chest (all 5 prizes)";
+            ImGui.AlignTextToFramePadding();
+            ImGui.TextUnformatted("Chest to scratch:");
+            ImGui.SameLine();
+            ImGui.SetNextItemWidth(-1);
+            var pick = configuration.KupoChestPick;
+            if (ImGui.BeginCombo("##KupoChest", pick == Data.KupoChestPick.RandomRight ? rightLabel : leftLabel))
+            {
+                if (ImGui.Selectable(leftLabel, pick == Data.KupoChestPick.Left))
+                {
+                    configuration.KupoChestPick = Data.KupoChestPick.Left;
+                    configuration.Save();
+                }
+                if (ImGui.Selectable(rightLabel, pick == Data.KupoChestPick.RandomRight))
+                {
+                    configuration.KupoChestPick = Data.KupoChestPick.RandomRight;
+                    configuration.Save();
+                }
+                ImGui.EndCombo();
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Left can only win 2nd-4th prize (avoids the jackpot and the\n" +
+                                 "consolation). Random right can win any of the 5 prizes.");
             ImGui.EndDisabled();
 
             ImGui.Spacing();

--- a/TheCollector/Windows/MainWindow.cs
+++ b/TheCollector/Windows/MainWindow.cs
@@ -83,8 +83,8 @@ public partial class MainWindow : Window, IDisposable
                 ImGui.EndTabItem();
             }
 
-            // The planner is Normal-system only; it has no meaningful equivalent in Firmament mode.
-            if (configuration.ActiveSystem != ScripSystemId.Firmament && ImGui.BeginTabItem("Planner"))
+            // The planner is Normal-system only; it has no meaningful equivalent in Firmament/Inspection mode.
+            if (!configuration.ActiveSystem.IsFirmamentLike() && ImGui.BeginTabItem("Planner"))
             {
                 ImGui.Spacing();
                 if (ImGui.BeginChild("##PlannerScroll", new Vector2(0, -1), false))
@@ -155,7 +155,7 @@ public partial class MainWindow : Window, IDisposable
             ImGui.TextUnformatted(label);
             ImGui.PopStyleColor();
 
-            var statusGoal = configuration.ActiveSystem == ScripSystemId.Firmament
+            var statusGoal = configuration.ActiveSystem.IsFirmamentLike()
                 ? configuration.FirmamentGoal
                 : configuration.Goal;
 
@@ -194,19 +194,23 @@ public partial class MainWindow : Window, IDisposable
 
     private void DrawSystemOption(string label, ScripSystemId id, bool requireShift = false)
     {
-        bool active = configuration.ActiveSystem == id;
-        if (active) ImGui.PushStyleColor(ImGuiCol.Button, UiTheme.Accent);
-        ImGui.BeginDisabled(!active && _automationHandler.IsRunning);
+        bool isCurrent = configuration.ActiveSystem == id;
+        // Resource Inspection is a sub-activity of Firmament, so keep the Firmament button lit
+        // while it's the active (internal) system.
+        bool highlight = isCurrent ||
+                         (id == ScripSystemId.Firmament && configuration.ActiveSystem == ScripSystemId.Inspection);
+        if (highlight) ImGui.PushStyleColor(ImGuiCol.Button, UiTheme.Accent);
+        ImGui.BeginDisabled(!isCurrent && _automationHandler.IsRunning);
         bool clicked = ImGui.Button(label);
         ImGui.EndDisabled();
-        if (active) ImGui.PopStyleColor();
+        if (highlight) ImGui.PopStyleColor();
 
         if (requireShift && ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
-            ImGui.SetTooltip(active
+            ImGui.SetTooltip(highlight
                 ? "Experimental feature."
                 : "Experimental — hold Shift and click to enable.");
 
-        if (clicked && !active && (!requireShift || ImGui.GetIO().KeyShift))
+        if (clicked && !isCurrent && (!requireShift || ImGui.GetIO().KeyShift))
         {
             configuration.ActiveSystem = id;
             configuration.Save();

--- a/TheCollector/Windows/PluginStatePresentation.cs
+++ b/TheCollector/Windows/PluginStatePresentation.cs
@@ -16,6 +16,7 @@ internal static class PluginStatePresentation
             PluginState.SpendingScrip             => UiTheme.Success,
             PluginState.AutoRetainer              => UiTheme.Info,
             PluginState.Deliveroo                 => UiTheme.Info,
+            PluginState.ProcessingArtisanList     => UiTheme.Accent,
             _                                     => UiTheme.Idle,
         };
 


### PR DESCRIPTION
What this PR adds (all changes has made for the Firmament experimental feature):
- Fix a bug where the collection was not starting after an artisan list was completed when the configuraiton "Collect on finish crafting an Artisan list" was enabled.
- Add "Kupo of Fortune" feature with dedicated configuration in the General tab
- Add "Resource Inspection" feature with new configurations "Run resource inspetion on autogather finish" and "Craft selected Artisan list on resource inspection finish"

Now a full loop gathering -> inspection -> crafting -> collecting -> repeat is possible when the following configurations are checked:
- Enable autogather on finish
- Run resource inspection on autogather finish
- Craft selected Artisan list on resource inspection finish
- Collect on finish crafting an Artisan list
- Pause Artisan when inventory is full, turn in, then resume

For this reason, a new termination configuration "Stop after n full loops" was added.

I tested the full loop with (2 loops) with a simple Artisan list of one expert recipe and a auto-gather list with the required materials. With the above configuration enabled is sufficient to start autogathering to begin the automation.
It worked: gathered -> inspected-> crafted-> collected -> gathered -> inspected-> crafted-> collected -> Stop.

Not gonna lie, I've heavily relied on AI to implement those features and the above is the only E2E test I performed.
But regardless, I wanted to open this PR beause some of this work may save you some time in future implementations :)